### PR TITLE
Fix: dbData in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dbData

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: near-developer-console-api:latest
     ports:
       - '8080:3001'
-    env_file:
-      - .env
   db:
     image: postgres
     restart: unless-stopped


### PR DESCRIPTION
As I'm running setup without devcontainer, the DB in docker uses local `dbData` dir. It should be git ignored not to pollute the staging environment.
Also, we don't have `.env` file and I don't see why it should be required.