### PR TITLE
Postman cleanup: remove unused RPC dto

### DIFF
--- a/backend/src/core/projects/dto.ts
+++ b/backend/src/core/projects/dto.ts
@@ -142,11 +142,3 @@ export const GetTransactionsSchema = Joi.object({
   contracts: Joi.array().items(Joi.string()),
   net: Joi.string(),
 });
-
-// get RPC data
-export interface GetRpcUsageDto {
-  project: string;
-}
-export const GetRpcUsageSchema = Joi.object({
-  project: Joi.string().required(),
-});


### PR DESCRIPTION
This object is no longer used as RPC metrics were moved to a separate module.