### PR TITLE
Hiding source maps based on Sentry recommendation

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,9 @@ const { withSentryConfig } = require('@sentry/nextjs');
 
 /** @type {import('next').NextConfig} */
 const moduleExports = {
+  sentry: {
+    hideSourceMaps: true, // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
+  },
   experimental: { esmExternals: true },
   reactStrictMode: true,
   webpack(config, options) {


### PR DESCRIPTION
When running the Next app locally, the following warning started being logged:

>warn  - In order to be able to deminify errors, @sentry/nextjs creates sourcemaps and uploads them to the Sentry server. Depending on your deployment setup, this means your original code may be visible in browser devtools in production. To prevent this, set hideSourceMaps to true in the sentry options in your next.config.js. To disable this warning without changing sourcemap behavior, set hideSourceMaps to false. (In @sentry/nextjs version 8.0.0 and beyond, this option will default to true.) See https://webpack.js.org/configuration/devtool/ and https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map for more information.

Sentry is recommending making these changes, and it will become the default behavior soon anyways.