### PR TITLE
Segment CDN workaround to avoid adblockers

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -49,6 +49,12 @@ const moduleExports = {
       },
     ];
   },
+  rewrites: async () => [
+    {
+      source: '/api/segment',
+      destination: 'https://api.segment.io/v1/batch',
+    },
+  ],
 };
 
 const sentryWebpackPluginOptions = {

--- a/frontend/utils/analytics.ts
+++ b/frontend/utils/analytics.ts
@@ -14,7 +14,14 @@ const anonymousId = uniqueId();
 function init() {
   if (segment) return console.log('Segment Analytics has already been initialized');
   //flushAt=1 is useful for testing new events
-  const options = config.deployEnv === 'LOCAL' ? { flushAt: 1 } : {};
+  const proxySettings =
+    typeof window === 'undefined'
+      ? {}
+      : {
+          host: `${window.location.protocol}//${window.location.host}`,
+          path: '/api/segment',
+        };
+  const options = config.deployEnv === 'LOCAL' ? { flushAt: 1, ...proxySettings } : proxySettings;
   segment = new Analytics(config.segment, options);
 }
 


### PR DESCRIPTION
Eventually, I didn't use [this](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/custom-proxy/) guide with CDN setup, but just proxied the requests with `next.js` functionality.

This may lead to an increased stress on server, but we're doing the same with Sentry and this should probably be trackable.

Please let me know if you have other concerns about that kind of setup.