### PR TITLE
fix: Fix error message on creating a duplicate NFT tutorial

### DIFF
--- a/frontend/pages/new-nft-tutorial.tsx
+++ b/frontend/pages/new-nft-tutorial.tsx
@@ -50,9 +50,15 @@ const NewNftTutorial: NextPageWithLayout = () => {
         name,
         error: e.message,
       });
-      setError('projectName', {
-        message: 'Something went wrong',
-      });
+      if (e.statusCode === 409) {
+        setError('projectName', {
+          message: 'Project name is already in use',
+        });
+      } else {
+        setError('projectName', {
+          message: 'Something went wrong',
+        });
+      }
     }
   };
 


### PR DESCRIPTION
Closes: https://pagodaplatform.atlassian.net/browse/DEC-582