### PR TITLE
Fixing identify() traits race condition bug

### DIFF
--- a/frontend/hooks/analytics.ts
+++ b/frontend/hooks/analytics.ts
@@ -3,10 +3,13 @@ import { useEffect } from 'react';
 
 import analytics from '@/utils/analytics';
 
+import { useAccount } from './user';
+
 let lastTrackedPage = '';
 
-export function usePageTracker() {
+export function useAnalytics() {
   const router = useRouter();
+  const { user } = useAccount();
 
   useEffect(() => {
     let page;
@@ -26,4 +29,16 @@ export function usePageTracker() {
       path: router.pathname,
     });
   }, [router.pathname]);
+
+  useEffect(() => {
+    if (user) {
+      // https://segment.com/docs/connections/spec/best-practices-identify/
+
+      analytics.identify(user.uid, {
+        email: user.email,
+        displayName: user.name,
+        userId: user.uid,
+      });
+    }
+  }, [user]);
 }

--- a/frontend/modules/core/components/AuthenticationForm/AuthenticationForm.tsx
+++ b/frontend/modules/core/components/AuthenticationForm/AuthenticationForm.tsx
@@ -98,7 +98,6 @@ export function AuthenticationForm({ onSignIn }: Props) {
 
       try {
         if (additional?.isNewUser) {
-          analytics.alias(socialResult.user.uid);
           analytics.track(`DC Signed up with ${provider.providerId.split('.')[0].toUpperCase()}`);
         } else {
           analytics.track(`DC Login via ${provider.providerId.split('.')[0].toUpperCase()}`);

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -21,9 +21,9 @@ import { SWRConfig, useSWRConfig } from 'swr';
 import { SimpleLayout } from '@/components/layouts/SimpleLayout';
 import { FeatherIconSheet } from '@/components/lib/FeatherIcon';
 import { Toaster } from '@/components/lib/Toast';
-import { usePageTracker } from '@/hooks/page-tracker';
+import { useAnalytics } from '@/hooks/analytics';
 import { useSelectedProjectRouteParamSync } from '@/hooks/selected-project';
-import { useAccount, useIdentity } from '@/hooks/user';
+import { useIdentity } from '@/hooks/user';
 import { DowntimeMode } from '@/modules/core/components/DowntimeMode';
 import SmallScreenNotice from '@/modules/core/components/SmallScreenNotice';
 import { useSettingsStore } from '@/stores/settings';
@@ -57,10 +57,9 @@ const unauthedPaths = [
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   useSelectedProjectRouteParamSync();
-  usePageTracker();
+  useAnalytics();
   const identity = useIdentity();
   const router = useRouter();
-  const { user } = useAccount();
   const { cache }: { cache: any } = useSWRConfig(); // https://github.com/vercel/swr/discussions/1494
   const initializeCurrentUserSettings = useSettingsStore((store) => store.initializeCurrentUserSettings);
 
@@ -93,17 +92,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     });
 
     return () => unsubscribe(); // TODO why lambda function?
-  }, [router, cache, user]);
-
-  useEffect(() => {
-    if (user) {
-      analytics.identify(user.uid, {
-        email: user.email,
-        displayName: user.name,
-        userId: user.uid,
-      });
-    }
-  }, [user]);
+  }, [router, cache]);
 
   const getLayout = Component.getLayout ?? ((page) => page);
 

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -99,10 +99,9 @@ export function RegisterForm() {
       setRegisterError('');
       analytics.track('DC Submitted email registration form');
       const auth = getAuth();
-      const registerResult = await createUserWithEmailAndPassword(auth, email, password);
+      await createUserWithEmailAndPassword(auth, email, password);
 
       try {
-        analytics.alias(registerResult.user.uid);
         analytics.track('DC Signed up with email', {
           status: 'success',
         });

--- a/frontend/utils/analytics.ts
+++ b/frontend/utils/analytics.ts
@@ -1,5 +1,4 @@
 import Analytics from 'analytics-node';
-import { uniqueId } from 'lodash-es';
 
 import config from './config';
 
@@ -8,8 +7,6 @@ export interface Dict {
 }
 
 let segment: Analytics;
-let userId: string;
-const anonymousId = uniqueId();
 
 function init() {
   if (segment) return console.log('Segment Analytics has already been initialized');
@@ -25,47 +22,33 @@ function init() {
   segment = new Analytics(config.segment, options);
 }
 
-function alias(id: string) {
-  userId = id;
-  segment.alias({
-    previousId: userId || anonymousId,
-    userId,
-  });
-}
-
 function track(eventLabel: string, properties?: Dict) {
-  const id = userId ? { userId } : { anonymousId };
   segment.track({
-    ...id,
     event: eventLabel,
     properties,
   });
 }
 
 function identify(id: string, traits: Record<string, any>) {
-  userId = id;
   segment.identify({
     traits,
-    userId,
+    userId: id,
   });
 }
 
-function pageView(name: string, properties?: Dict) {
-  const id = userId ? { userId } : { anonymousId };
+async function pageView(name: string, properties?: Dict) {
   segment.page({
-    ...id,
     name,
     properties,
   });
 }
 
 function reset() {
-  segment.flush();
   track('Logout');
+  segment.flush();
 }
 
 const fns = {
-  alias,
   identify,
   init,
   pageView,


### PR DESCRIPTION
Closes: https://pagodaplatform.atlassian.net/browse/DEC-629

The `analytics.identify()` call was triggered before the `user` object had finished loading - so the `traits` object ended up being empty sometimes.