### PR TITLE
Including support for GTM for NEAR Foundation

### DIFF
--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,6 +1,8 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 import { getCssText } from '@/styles/stitches';
+import config from '@/utils/config';
 import { initializeTheme } from '@/utils/initialize-theme';
 
 class MyDocument extends Document {
@@ -15,7 +17,27 @@ class MyDocument extends Document {
           <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
 
           <style id="stitches" dangerouslySetInnerHTML={{ __html: getCssText() }} />
+
+          {/*
+            https://nextjs.org/docs/messages/next-script-for-ga
+            
+            The following Google Tag Manager inclusion is for the NEAR Foundation.
+            Analytics for Pagoda are tracked through Segment.
+          */}
+
+          {config.googleTagManagerId && (
+            <Script id="gtm" strategy="afterInteractive">
+              {`
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','${config.googleTagManagerId}');
+              `}
+            </Script>
+          )}
         </Head>
+
         <body>
           <script dangerouslySetInnerHTML={{ __html: initializeTheme }} />
           <script defer src="https://p5c5wl39l4g2.statuspage.io/embed/script.js"></script>

--- a/frontend/utils/config.ts
+++ b/frontend/utils/config.ts
@@ -92,6 +92,7 @@ interface AppConfig {
   analyticsIframeUrl: RpcNets;
   launchDarklyEnv: string;
   gleapAuth?: string;
+  googleTagManagerId?: string;
 }
 
 // TODO remove recommended RPC since there is no longer a separate URL from default
@@ -143,6 +144,7 @@ const config: AppConfig = {
   },
   launchDarklyEnv: process.env.NEXT_PUBLIC_LAUNCHDARKLY_SDK_ENV,
   gleapAuth: process.env.NEXT_PUBLIC_GLEAP_AUTH_KEY,
+  googleTagManagerId: process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID,
 };
 
 export default config;


### PR DESCRIPTION
Closes: https://pagodaplatform.atlassian.net/browse/DEC-530

I've already set up the `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID` variable in Vercel for production only. All other environments won't load the NEAR Foundation's GTM instance.

I'm starting to worry about end user performance impact now that we have FullStory, Segment, and Google Tag Manager running on the frontend. Might be worth revisiting down the road to make sure we need all three.