### PR TITLE
Switch wallet connection to be only required when interacting with a call method

### DIFF
--- a/frontend/modules/contracts/components/ContractTransaction.tsx
+++ b/frontend/modules/contracts/components/ContractTransaction.tsx
@@ -242,6 +242,10 @@ const ContractTransactionForm = ({ accountId, contract, selector, onTxResult, on
 
   const initMethods = useCallback(async () => {
     try {
+      if (!contractAbi) {
+        return;
+      }
+
       const methods = await initContractMethods(contract.net.toLowerCase(), contract.address, contractAbi);
       setContractMethods(methods);
     } catch (error) {


### PR DESCRIPTION
Changes:
1. Remove `1. Account` section.
2. Enable the form if a wallet is not connected.
3. Get contract methods if a wallet is not connected.
4. Move `Connect A Wallet` form to `Transaction Parameters` section. 
5. Set form state in Session Storage when connecting to a wallet

`Connect A Wallet` form section looks exactly the same as before. The design from the ticket is no longer valid, as it's containing `accountId` input.