### PR TITLE
Refactor: alerts discriminated union

### DIFF
--- a/backend/src/modules/alerts/alerts.controller.ts
+++ b/backend/src/modules/alerts/alerts.controller.ts
@@ -177,22 +177,33 @@ export class AlertsController {
     @Body() dto: Api.Mutation.Input<'/alerts/createDestination'>,
   ): Promise<Api.Mutation.Output<'/alerts/createDestination'>> {
     try {
-      const type = dto.type;
-      switch (type) {
+      const { config, ...rest } = dto;
+      switch (config.type) {
         case 'WEBHOOK':
           return await this.alertsService.createWebhookDestination(
             req.user,
-            dto,
+            rest,
+            config,
           );
         case 'EMAIL':
-          return await this.alertsService.createEmailDestination(req.user, dto);
+          return await this.alertsService.createEmailDestination(
+            req.user,
+            rest,
+            config,
+          );
         case 'TELEGRAM':
           return await this.alertsService.createTelegramDestination(
             req.user,
-            dto,
+            rest,
           );
         default:
-          assertUnreachable(type);
+          assertUnreachable(
+            config,
+            (config) =>
+              (
+                config as Api.Mutation.Input<'/alerts/createDestination'>['config']
+              ).type,
+          );
       }
     } catch (e: any) {
       throw mapError(e);
@@ -276,22 +287,32 @@ export class AlertsController {
     @Body() dto: Api.Mutation.Input<'/alerts/updateDestination'>,
   ): Promise<Api.Mutation.Output<'/alerts/updateDestination'>> {
     try {
-      const type = dto.type;
-      switch (type) {
+      const { config, ...rest } = dto;
+      switch (config.type) {
         case 'WEBHOOK':
           return await this.alertsService.updateWebhookDestination(
             req.user,
-            dto,
+            rest,
+            config,
           );
         case 'EMAIL':
-          return await this.alertsService.updateEmailDestination(req.user, dto);
+          return await this.alertsService.updateEmailDestination(
+            req.user,
+            rest,
+          );
         case 'TELEGRAM':
           return await this.alertsService.updateTelegramDestination(
             req.user,
-            dto,
+            rest,
           );
         default:
-          assertUnreachable(type);
+          assertUnreachable(
+            config,
+            (config) =>
+              (
+                config as Api.Mutation.Input<'/alerts/updateDestination'>['config']
+              ).type,
+          );
       }
     } catch (e: any) {
       throw mapError(e);

--- a/backend/src/modules/alerts/alerts.service.ts
+++ b/backend/src/modules/alerts/alerts.service.ts
@@ -564,9 +564,9 @@ export class AlertsService {
     user: User,
     {
       name = 'Webhook Destination',
-      config: { url },
       projectSlug,
-    }: Alerts.CreateWebhookDestinationInput,
+    }: Alerts.CreateBaseDestinationInput,
+    { url }: Alerts.CreateWebhookDestinationConfig,
   ) {
     await this.projectPermissions.checkUserProjectPermission(
       user.id,
@@ -620,9 +620,9 @@ export class AlertsService {
     user: User,
     {
       name = 'Email Destination',
-      config: { email },
       projectSlug,
-    }: Alerts.CreateEmailDestinationInput,
+    }: Alerts.CreateBaseDestinationInput,
+    { email }: Alerts.CreateEmailDestinationConfig,
   ) {
     await this.projectPermissions.checkUserProjectPermission(
       user.id,
@@ -710,7 +710,7 @@ export class AlertsService {
     {
       name = 'Telegram Destination',
       projectSlug,
-    }: Alerts.CreateTelegramDestinationInput,
+    }: Alerts.CreateBaseDestinationInput,
   ) {
     await this.projectPermissions.checkUserProjectPermission(
       user.id,
@@ -916,9 +916,10 @@ export class AlertsService {
 
   async updateWebhookDestination(
     callingUser: User,
-    dto: Alerts.UpdateWebhookDestinationInput,
+    dto: Alerts.UpdateDestinationBaseInput,
+    config: Alerts.UpdateWebhookDestinationConfig,
   ) {
-    const { id, name, config } = dto;
+    const { id, name } = dto;
     await this.checkUserDestinationPermission(callingUser.id, id);
 
     try {
@@ -962,7 +963,7 @@ export class AlertsService {
 
   async updateEmailDestination(
     callingUser: User,
-    dto: Alerts.UpdateEmailDestinationInput,
+    dto: Alerts.UpdateDestinationBaseInput,
   ) {
     const { id, name } = dto;
     await this.checkUserDestinationPermission(callingUser.id, id);
@@ -1001,7 +1002,7 @@ export class AlertsService {
 
   async updateTelegramDestination(
     callingUser: User,
-    dto: Alerts.UpdateTelegramDestinationInput,
+    dto: Alerts.UpdateDestinationBaseInput,
   ) {
     const { id, name } = dto;
     await this.checkUserDestinationPermission(callingUser.id, id);

--- a/backend/src/modules/alerts/dto.ts
+++ b/backend/src/modules/alerts/dto.ts
@@ -146,36 +146,36 @@ export const GetAlertDetailsSchema = Joi.object<
 });
 
 const WebhookDestinationSchema = Joi.object<
-  Alerts.CreateWebhookDestinationInput['config'],
+  Alerts.CreateWebhookDestinationConfig,
   true
 >({
+  type: Joi.string().valid('WEBHOOK').required(),
   url: Joi.string().required(),
 });
 const EmailDestinationSchema = Joi.object<
-  Alerts.CreateEmailDestinationInput['config'],
+  Alerts.CreateEmailDestinationConfig,
   true
 >({
+  type: Joi.string().valid('EMAIL').required(),
   email: Joi.string().required(),
 });
 const TelegramDestinationSchema = Joi.object<
-  Alerts.CreateTelegramDestinationInput['config'],
+  Alerts.CreateTelegramDestinationConfig,
   true
->({});
+>({
+  type: Joi.string().valid('TELEGRAM').required(),
+});
 export const CreateDestinationSchema = Joi.object<
   Api.Mutation.Input<'/alerts/createDestination'>,
   true
 >({
   name: Joi.string(),
-  type: Joi.string().valid('WEBHOOK', 'EMAIL', 'TELEGRAM').required(),
   projectSlug: Joi.string().required(),
-  config: Joi.alternatives()
-    .conditional('config.type', {
-      switch: [
-        { is: 'WEBHOOK', then: WebhookDestinationSchema },
-        { is: 'EMAIL', then: EmailDestinationSchema },
-        { is: 'TELEGRAM', then: TelegramDestinationSchema },
-      ],
-    })
+  config: Joi.alternatives([
+    WebhookDestinationSchema,
+    EmailDestinationSchema,
+    TelegramDestinationSchema,
+  ])
     // TODO: fix any
     .required() as any,
 });
@@ -210,22 +210,35 @@ export const DisableDestinationSchema = EnableDestinationSchema;
 
 // update destination
 const UpdateWebhookDestinationSchema = Joi.object<
-  Alerts.UpdateWebhookDestinationInput['config'],
+  Alerts.UpdateWebhookDestinationConfig,
   true
 >({
+  type: Joi.string().valid('WEBHOOK').required(),
   url: Joi.string(),
+});
+const UpdateEmailDestinationSchema = Joi.object<
+  Alerts.UpdateEmailDestinationConfig,
+  true
+>({
+  type: Joi.string().valid('EMAIL').required(),
+});
+const UpdateTelegramDestinationSchema = Joi.object<
+  Alerts.UpdateTelegramDestinationConfig,
+  true
+>({
+  type: Joi.string().valid('TELEGRAM').required(),
 });
 export const UpdateDestinationSchema = Joi.object<
   Api.Mutation.Input<'/alerts/updateDestination'>,
   true
 >({
   id: Joi.number().required(),
-  type: Joi.string().required(),
   name: Joi.string(),
-  config: Joi.alternatives().conditional('config.type', {
-    switch: [{ is: 'WEBHOOK', then: UpdateWebhookDestinationSchema }],
-    // TODO: fix any
-  }) as any,
+  config: Joi.alternatives([
+    UpdateWebhookDestinationSchema,
+    UpdateEmailDestinationSchema,
+    UpdateTelegramDestinationSchema,
+  ]) as any,
 });
 
 // verify email

--- a/common/types/alerts/alerts.schema.ts
+++ b/common/types/alerts/alerts.schema.ts
@@ -1,7 +1,6 @@
 import {
   Alert as AlertDatabase,
   Destination as DestinationDatabase,
-  DestinationType,
   EmailDestination as EmailDestinationDatabase,
   TelegramDestination as TelegramDestinationDatabase,
   WebhookDestination as WebhookDestinationDatabase,
@@ -82,33 +81,29 @@ export type CreateAlertInput =
   | CreateAcctBalPctAlertInput
   | CreateAcctBalNumAlertInput;
 
-type CreateBaseDestinationInput = {
+export type CreateBaseDestinationInput = {
   name?: string;
-  type: DestinationType;
   projectSlug: string;
 };
 
-export type CreateWebhookDestinationInput = CreateBaseDestinationInput & {
+export type CreateWebhookDestinationConfig = {
   type: 'WEBHOOK';
-  config: {
-    url: string;
-  };
+  url: string;
 };
-export type CreateEmailDestinationInput = CreateBaseDestinationInput & {
+export type CreateEmailDestinationConfig = {
   type: 'EMAIL';
-  config: {
-    email: string;
-  };
+  email: string;
 };
-export type CreateTelegramDestinationInput = CreateBaseDestinationInput & {
+export type CreateTelegramDestinationConfig = {
   type: 'TELEGRAM';
-  config?: Record<string, never>; // eslint recommended typing for empty object
 };
 
-export type CreateDestinationInput =
-  | CreateWebhookDestinationInput
-  | CreateEmailDestinationInput
-  | CreateTelegramDestinationInput;
+export type CreateDestinationInput = CreateBaseDestinationInput & {
+  config:
+    | CreateWebhookDestinationConfig
+    | CreateEmailDestinationConfig
+    | CreateTelegramDestinationConfig;
+};
 
 type BaseDestination = Pick<
   DestinationDatabase,
@@ -135,34 +130,36 @@ export type Destination =
   | EmailDestination
   | TelegramDestination;
 
-type UpdateDestinationBaseInput = {
+export type UpdateDestinationBaseInput = {
   id: number;
-  type: DestinationType;
   name?: string;
 };
-export type UpdateWebhookDestinationInput = UpdateDestinationBaseInput & {
+export type UpdateWebhookDestinationConfig = {
   type: 'WEBHOOK';
-  config: {
-    url: string;
-  };
+  url: string;
 };
-export type UpdateEmailDestinationInput = UpdateDestinationBaseInput & {
+export type UpdateEmailDestinationConfig = {
   type: 'EMAIL';
 };
-export type UpdateTelegramDestinationInput = UpdateDestinationBaseInput & {
+export type UpdateTelegramDestinationConfig = {
   type: 'TELEGRAM';
 };
 
-export type UpdateDestinationInput =
-  | UpdateWebhookDestinationInput
-  | UpdateEmailDestinationInput
-  | UpdateTelegramDestinationInput;
-
-type EnabledDestination = Pick<DestinationDatabase, 'id' | 'name' | 'type'> & {
+export type UpdateDestinationInput = UpdateDestinationBaseInput & {
   config:
-    | Pick<EmailDestinationDatabase, 'email'>
-    | Pick<WebhookDestinationDatabase, 'url'>
-    | Pick<TelegramDestinationDatabase, 'chatTitle' | 'startToken'>;
+    | UpdateWebhookDestinationConfig
+    | UpdateEmailDestinationConfig
+    | UpdateTelegramDestinationConfig;
+};
+
+type EnabledDestination = Pick<DestinationDatabase, 'id' | 'name'> & {
+  config:
+    | ({ type: 'EMAIL' } & Pick<EmailDestinationDatabase, 'email'>)
+    | ({ type: 'WEBHOOK' } & Pick<WebhookDestinationDatabase, 'url'>)
+    | ({ type: 'TELEGRAM' } & Pick<
+        TelegramDestinationDatabase,
+        'chatTitle' | 'startToken'
+      >);
 };
 
 export type Alert = Pick<

--- a/frontend/modules/alerts/components/NewDestinationModal.tsx
+++ b/frontend/modules/alerts/components/NewDestinationModal.tsx
@@ -1,8 +1,9 @@
+import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
-import type { DestinationType } from '@pc/database/clients/alerts';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
+import type { KeyedMutator } from 'swr';
 
 import { Badge } from '@/components/lib/Badge';
 import { Box } from '@/components/lib/Box';
@@ -17,6 +18,7 @@ import { Text } from '@/components/lib/Text';
 import { openToast } from '@/components/lib/Toast';
 import { formValidations } from '@/utils/constants';
 import { StableId } from '@/utils/stable-ids';
+import type { MapDiscriminatedUnion } from '@/utils/types';
 
 import { createDestination, useDestinations } from '../hooks/destinations';
 import { useVerifyDestinationInterval } from '../hooks/verify-destination-interval';
@@ -26,29 +28,47 @@ import { TelegramDestinationVerification } from './TelegramDestinationVerificati
 import { WebhookDestinationSecret } from './WebhookDestinationSecret';
 
 type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
+type DestinationType = Destination['type'];
+type MappedDestination<K extends DestinationType> = MapDiscriminatedUnion<Destination, 'type'>[K];
 
-interface Props {
-  onCreate?: (destination: Destination) => void;
-  onVerify?: (destination: Destination) => void;
+interface Props<K extends DestinationType> {
+  onCreate?: (destination: MappedDestination<K>) => void;
+  onVerify?: (destination: MappedDestination<K>) => void;
   projectSlug: string;
   show: boolean;
   setShow: (show: boolean) => void;
 }
 
-interface FormProps extends Props {
+interface FormProps<K extends DestinationType> extends Props<K> {
   setIsCreated: (value: boolean) => void;
 }
 
-function useNewDestinationForm<T extends FieldValues>(props: FormProps) {
+function useNewDestinationForm<T extends FieldValues, K extends DestinationType>(props: FormProps<K>) {
   const { mutate } = useDestinations(props.projectSlug);
-  const [destination, setDestination] = useState<Destination>();
+  const [destination, setDestination] = useState<MappedDestination<K>>();
   const form = useForm<T>();
 
-  useVerifyDestinationInterval(destination, mutate, props.setShow, props.onVerify);
+  useVerifyDestinationInterval(
+    destination,
+    mutate as unknown as KeyedMutator<MappedDestination<K>[]>,
+    useCallback(
+      (nextDestination) => {
+        props.onVerify?.(nextDestination);
+        props.setShow(false);
+      },
+      [props],
+    ),
+  );
 
-  async function create(data: Api.Mutation.Input<'/alerts/createDestination'>) {
+  async function create(
+    data: Omit<Api.Mutation.Input<'/alerts/createDestination'>, 'config'>,
+    config: MapDiscriminatedUnion<Api.Mutation.Input<'/alerts/createDestination'>['config'], 'type'>[K],
+  ) {
     try {
-      const destination = await createDestination(data);
+      const destination = (await createDestination({
+        ...data,
+        config,
+      } as Alerts.CreateDestinationInput)) as MappedDestination<K>;
 
       mutate((state) => {
         return [...(state || []), destination];
@@ -74,7 +94,7 @@ function useNewDestinationForm<T extends FieldValues>(props: FormProps) {
   };
 }
 
-export function NewDestinationModal(props: Props) {
+export function NewDestinationModal(props: Props<DestinationType>) {
   return (
     <Dialog.Root open={props.show} onOpenChange={props.setShow}>
       <Dialog.Content title="New Destination" size="m">
@@ -89,7 +109,7 @@ export function NewDestinationModal(props: Props) {
   );
 }
 
-function ModalContent(props: Props) {
+function ModalContent(props: Props<DestinationType>) {
   const [destinationType, setDestinationType] = useState<DestinationType>('TELEGRAM');
   const [isCreated, setIsCreated] = useState(false);
 
@@ -128,22 +148,24 @@ function ModalContent(props: Props) {
         </CheckboxCard.Group>
       )}
 
-      {destinationType === 'TELEGRAM' && <TelegramDestinationForm setIsCreated={setIsCreated} {...props} />}
-      {destinationType === 'WEBHOOK' && <WebhookDestinationForm setIsCreated={setIsCreated} {...props} />}
-      {destinationType === 'EMAIL' && <EmailDestinationForm setIsCreated={setIsCreated} {...props} />}
+      {destinationType === 'TELEGRAM' && (
+        <TelegramDestinationForm setIsCreated={setIsCreated} {...(props as Props<'TELEGRAM'>)} />
+      )}
+      {destinationType === 'WEBHOOK' && (
+        <WebhookDestinationForm setIsCreated={setIsCreated} {...(props as Props<'WEBHOOK'>)} />
+      )}
+      {destinationType === 'EMAIL' && (
+        <EmailDestinationForm setIsCreated={setIsCreated} {...(props as Props<'EMAIL'>)} />
+      )}
     </Flex>
   );
 }
 
-function TelegramDestinationForm(props: FormProps) {
+function TelegramDestinationForm(props: FormProps<'TELEGRAM'>) {
   const { create, destination, form } = useNewDestinationForm(props);
 
   async function submitForm() {
-    await create({
-      config: {},
-      projectSlug: props.projectSlug,
-      type: 'TELEGRAM',
-    });
+    await create({ projectSlug: props.projectSlug }, { type: 'TELEGRAM' });
   }
 
   if (destination)
@@ -191,17 +213,11 @@ interface WebhookFormData {
   url: string;
 }
 
-function WebhookDestinationForm(props: FormProps) {
-  const { create, destination, form } = useNewDestinationForm<WebhookFormData>(props);
+function WebhookDestinationForm(props: FormProps<'WEBHOOK'>) {
+  const { create, destination, form } = useNewDestinationForm<WebhookFormData, 'WEBHOOK'>(props);
 
   async function submitForm(data: WebhookFormData) {
-    await create({
-      config: {
-        url: data.url,
-      },
-      projectSlug: props.projectSlug,
-      type: 'WEBHOOK',
-    });
+    await create({ projectSlug: props.projectSlug }, { type: 'WEBHOOK', url: data.url });
   }
 
   if (destination)
@@ -266,17 +282,11 @@ interface EmailFormData {
   email: string;
 }
 
-function EmailDestinationForm(props: FormProps) {
-  const { create, destination, form } = useNewDestinationForm<EmailFormData>(props);
+function EmailDestinationForm(props: FormProps<'EMAIL'>) {
+  const { create, destination, form } = useNewDestinationForm<EmailFormData, 'EMAIL'>(props);
 
   async function submitForm(data: EmailFormData) {
-    await create({
-      config: {
-        email: data.email,
-      },
-      projectSlug: props.projectSlug,
-      type: 'EMAIL',
-    });
+    await create({ projectSlug: props.projectSlug }, { type: 'EMAIL', email: data.email });
   }
 
   if (destination)

--- a/frontend/modules/alerts/components/WebhookDestinationSecret.tsx
+++ b/frontend/modules/alerts/components/WebhookDestinationSecret.tsx
@@ -9,14 +9,18 @@ import { Text } from '@/components/lib/Text';
 import { openToast } from '@/components/lib/Toast';
 import { ConfirmModal } from '@/components/modals/ConfirmModal';
 import { StableId } from '@/utils/stable-ids';
+import type { MapDiscriminatedUnion } from '@/utils/types';
 
 import { rotateWebhookDestinationSecret } from '../hooks/destinations';
 
-type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
+type WebhookDestination = MapDiscriminatedUnion<
+  Api.Query.Output<'/alerts/listDestinations'>[number],
+  'type'
+>['WEBHOOK'];
 
 interface Props {
-  destination: Destination;
-  onRotate?: (d: Destination) => void;
+  destination: WebhookDestination;
+  onRotate?: (d: WebhookDestination) => void;
 }
 
 const ROTATION_WARNING =

--- a/frontend/modules/alerts/hooks/destinations.ts
+++ b/frontend/modules/alerts/hooks/destinations.ts
@@ -1,3 +1,4 @@
+import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
 import useSWR from 'swr';
 
@@ -5,6 +6,7 @@ import { openToast } from '@/components/lib/Toast';
 import { useIdentity } from '@/hooks/user';
 import analytics from '@/utils/analytics';
 import { authenticatedPost } from '@/utils/http';
+import type { MapDiscriminatedUnion } from '@/utils/types';
 
 export async function createDestination(data: Api.Mutation.Input<'/alerts/createDestination'>) {
   const destination = await authenticatedPost('/alerts/createDestination', {
@@ -40,7 +42,9 @@ export async function deleteDestination(destination: Api.Mutation.Input<'/alerts
   return false;
 }
 
-export async function updateDestination(data: Api.Mutation.Input<'/alerts/updateDestination'>) {
+export async function updateDestination<K extends Alerts.Destination['type']>(
+  data: Api.Mutation.Input<'/alerts/updateDestination'>,
+) {
   const destination = await authenticatedPost('/alerts/updateDestination', {
     ...data,
   });
@@ -51,7 +55,7 @@ export async function updateDestination(data: Api.Mutation.Input<'/alerts/update
     id: destination.id,
   });
 
-  return destination;
+  return destination as MapDiscriminatedUnion<Alerts.Destination, 'type'>[K];
 }
 
 export function useDestinations(projectSlug: string | undefined) {

--- a/frontend/modules/alerts/hooks/verify-destination-interval.ts
+++ b/frontend/modules/alerts/hooks/verify-destination-interval.ts
@@ -1,46 +1,39 @@
-import type { Api } from '@pc/common/types/api';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import type { KeyedMutator } from 'swr';
 
 import { openToast } from '@/components/lib/Toast';
 
-type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
-
-export function useVerifyDestinationInterval(
-  destination: Destination | undefined,
-  mutate: KeyedMutator<Destination[]>,
-  setShow: (isOpen: boolean) => void,
-  onVerify?: (destination: Destination) => void,
+export function useVerifyDestinationInterval<D extends { id: number; isValid: boolean }>(
+  destination: D | undefined,
+  mutate: KeyedMutator<D[]>,
+  onVerify: (destination: D) => void,
 ) {
-  const onVerifyCallback = useCallback((dest: Destination) => {
-    onVerify && onVerify(dest);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useEffect(() => {
-    if (!destination || destination.isValid) return;
+    if (!destination || destination.isValid) {
+      return;
+    }
 
     const interval = setInterval(async () => {
-      const result = await mutate();
-      const dest = result?.find((d) => d.id === destination.id);
-
-      if (dest?.isValid) {
-        onVerifyCallback(dest);
-
-        clearInterval(interval);
-
-        openToast({
-          type: 'success',
-          title: 'Destination Verified',
-          description: 'Your destination is ready to go.',
-        });
-
-        setShow(false);
+      const nextDestinations = await mutate();
+      if (!nextDestinations) {
+        return;
       }
+      const nextDestination = nextDestinations.find((lookupDestination) => lookupDestination.id === destination.id);
+      if (!nextDestination || !nextDestination.isValid) {
+        return;
+      }
+
+      clearInterval(interval);
+
+      openToast({
+        type: 'success',
+        title: 'Destination Verified',
+        description: 'Your destination is ready to go.',
+      });
+
+      onVerify(nextDestination);
     }, 1000);
 
-    return () => {
-      clearInterval(interval);
-    };
-  }, [destination, mutate, setShow, onVerifyCallback]);
+    return () => clearInterval(interval);
+  }, [destination, mutate, onVerify]);
 }


### PR DESCRIPTION
I'm factoring in the type of the destination to `config` objects to help us discriminate configs.