### PR TITLE
Refactor: stringify dates

### DIFF
--- a/backend/src/modules/alerts/dto.ts
+++ b/backend/src/modules/alerts/dto.ts
@@ -258,7 +258,7 @@ export const ListTriggeredAlertSchema = Joi.object<
   environmentSubId: Joi.number().required(),
   skip: Joi.number().integer().min(0).optional(),
   take: Joi.number().integer().min(0).max(100).optional(),
-  pagingDateTime: Joi.date().optional(),
+  pagingDateTime: Joi.date().iso().optional() as unknown as Joi.StringSchema,
   alertId: Joi.number().integer().positive().optional(),
 });
 

--- a/backend/src/modules/alerts/triggered-alerts/triggered-alerts.controller.ts
+++ b/backend/src/modules/alerts/triggered-alerts/triggered-alerts.controller.ts
@@ -48,7 +48,7 @@ export class TriggeredAlertsController {
         environmentSubId,
         skip || 0,
         take || 100,
-        pagingDateTime!,
+        pagingDateTime ? new Date(pagingDateTime) : undefined,
         alertId,
       );
     } catch (e: any) {

--- a/backend/src/modules/alerts/triggered-alerts/triggered-alerts.service.ts
+++ b/backend/src/modules/alerts/triggered-alerts/triggered-alerts.service.ts
@@ -26,7 +26,7 @@ export class TriggeredAlertsService {
     environmentSubId: Alert['environmentSubId'],
     skip: number,
     take: number,
-    pagingDateTime: Date,
+    pagingDateTime: Date | undefined,
     alertId?: number,
   ) {
     await this.projectPermissions.checkUserProjectEnvPermission(
@@ -106,7 +106,7 @@ export class TriggeredAlertsService {
   }
 
   private determineWhereClause(
-    pagingDateTime: Date,
+    pagingDateTime: Date | undefined,
     projectSlug: string,
     environmentSubId: number,
     alertId?: number,

--- a/backend/src/modules/rpcstats/dto.ts
+++ b/backend/src/modules/rpcstats/dto.ts
@@ -14,7 +14,7 @@ export const EndpointMetricsSchema = Joi.object<
   endDateTime: Joi.string().required(),
   skip: Joi.number().integer().min(0).optional(),
   take: Joi.number().integer().min(0).max(100).optional(),
-  pagingDateTime: Joi.date().optional(),
+  pagingDateTime: Joi.date().iso().optional() as unknown as Joi.StringSchema,
   filter: Joi.alternatives(
     Joi.object({
       type: Joi.string().valid('date'),

--- a/common/types/alerts/triggered-alerts.schema.ts
+++ b/common/types/alerts/triggered-alerts.schema.ts
@@ -24,7 +24,7 @@ export namespace Query {
       environmentSubId: number;
       skip?: number;
       take?: number;
-      pagingDateTime?: Date;
+      pagingDateTime?: string;
       alertId?: number;
     };
     export type GetTriggeredAlertDetails = { slug: string };

--- a/common/types/rpcstats/rpcstats.schema.ts
+++ b/common/types/rpcstats/rpcstats.schema.ts
@@ -50,7 +50,7 @@ export namespace Query {
       endDateTime: string;
       skip?: number;
       take?: number;
-      pagingDateTime?: Date;
+      pagingDateTime?: string;
       filter:
         | {
             type: 'date';

--- a/frontend/modules/alerts/hooks/triggered-alerts.ts
+++ b/frontend/modules/alerts/hooks/triggered-alerts.ts
@@ -43,7 +43,7 @@ export function useTriggeredAlerts(
         projectSlug: projectSlug!,
         take,
         skip,
-        pagingDateTime: pagination.state.pagingDateTime,
+        pagingDateTime: pagination.state.pagingDateTime?.toISOString(),
         alertId: filters?.alertId,
       });
     },


### PR DESCRIPTION
The dates are moving between frontend and backend as strings, but we don't have it explicitly.
Let's put the proper types here.