### PR TITLE
Refactor: config conditions

### DIFF
--- a/backend/src/config/validate.ts
+++ b/backend/src/config/validate.ts
@@ -45,12 +45,6 @@ export interface AppConfig {
     credentials: string;
     clientConfig: string;
   };
-  dev: {
-    mock: {
-      rpcProvisioningService: boolean;
-      email: boolean;
-    };
-  };
   log: {
     queries: boolean;
     indexer: boolean;
@@ -63,9 +57,8 @@ export interface AppConfig {
       tokenExpiryMin: number;
       resendVerificationRatelimitMillis: number;
     };
-    telegram: {
+    telegram?: {
       tokenExpiryMin: number;
-      enableWebhook: boolean;
       botToken?: string;
       secret?: string;
     };
@@ -75,6 +68,7 @@ export interface AppConfig {
     apiKey: string;
   };
   email: {
+    mock: boolean;
     noReply: string;
     alerts: {
       noReply: string;
@@ -93,6 +87,7 @@ export interface AppConfig {
   };
   metricsPort: string;
   rpcProvisioningService: {
+    mock: boolean;
     apiKey: string;
     url: string;
   };
@@ -163,12 +158,6 @@ const appConfigSchema = Joi.object({
     credentials: Joi.string(),
     clientConfig: Joi.string(),
   },
-  dev: {
-    mock: {
-      rpcProvisioningService: Joi.boolean().optional().default(false),
-      email: Joi.boolean().optional().default(false),
-    },
-  },
   log: {
     queries: Joi.boolean().optional().default(false),
     indexer: Joi.boolean().optional().default(false),
@@ -183,7 +172,6 @@ const appConfigSchema = Joi.object({
     }),
     telegram: Joi.object({
       tokenExpiryMin: Joi.number().optional().default(10000), // TODO set to a small value once requesting a new token is possible
-      enableWebhook: Joi.boolean().optional().default(false),
       botToken: Joi.string().when('/alerts.telegram.enableWebhook', {
         is: Joi.boolean().valid(false),
         then: Joi.optional().allow(''),
@@ -192,13 +180,14 @@ const appConfigSchema = Joi.object({
         is: Joi.boolean().valid(false),
         then: Joi.optional().allow(''),
       }),
-    }),
+    }).optional(),
   },
   mailgun: {
     domain: Joi.string(),
     apiKey: Joi.string(),
   },
   email: {
+    mock: Joi.boolean().optional().default(false),
     noReply: Joi.string(),
     alerts: {
       noReply: Joi.string(),
@@ -217,6 +206,7 @@ const appConfigSchema = Joi.object({
   },
   metricsPort: Joi.number().optional().default(3030),
   rpcProvisioningService: {
+    mock: Joi.boolean().optional().default(false),
     url: Joi.string()
       .uri({ scheme: 'http' })
       .when('/dev.mock.rpcProvisioningService', {
@@ -303,12 +293,6 @@ export default function validate(config: Record<string, unknown>): AppConfig {
       credentials: config.FIREBASE_CREDENTIALS,
       clientConfig: config.FIREBASE_CLIENT_CONFIG,
     },
-    dev: {
-      mock: {
-        rpcProvisioningService: config.MOCK_KEY_SERVICE,
-        email: config.MOCK_EMAIL_SERVICE,
-      },
-    },
     log: {
       queries: config.LOG_QUERIES,
       indexer: config.LOG_INDEXER,
@@ -322,18 +306,20 @@ export default function validate(config: Record<string, unknown>): AppConfig {
         resendVerificationRatelimitMillis:
           config.RESEND_VERIFICATION_RATE_LIMIT_MILLIS,
       },
-      telegram: {
-        tokenExpiryMin: config.TELEGRAM_TOKEN_EXPIRY_MIN,
-        enableWebhook: config.TELEGRAM_ENABLE_WEBHOOK,
-        botToken: config.TELEGRAM_BOT_TOKEN,
-        secret: config.TELEGRAM_SECRET,
-      },
+      telegram: config.TELEGRAM_ENABLE_WEBHOOK
+        ? {
+            tokenExpiryMin: config.TELEGRAM_TOKEN_EXPIRY_MIN,
+            botToken: config.TELEGRAM_BOT_TOKEN,
+            secret: config.TELEGRAM_SECRET,
+          }
+        : undefined,
     },
     mailgun: {
       domain: config.MAILGUN_DOMAIN,
       apiKey: config.MAILGUN_API_KEY,
     },
     email: {
+      mock: config.MOCK_EMAIL_SERVICE,
       noReply: config.EMAIL_NO_REPLY,
       alerts: {
         noReply: config.EMAIL_ALERTS_NO_REPLY,
@@ -354,6 +340,7 @@ export default function validate(config: Record<string, unknown>): AppConfig {
     },
     metricsPort: config.METRICS_PORT,
     rpcProvisioningService: {
+      mock: Boolean(config.MOCK_KEY_SERVICE),
       url: config.RPC_API_KEYS_URL,
       apiKey: config.RPC_API_KEYS_API_KEY,
     },

--- a/backend/src/core/email/email.module.ts
+++ b/backend/src/core/email/email.module.ts
@@ -10,7 +10,7 @@ const emailFactory = {
   useFactory: (
     configService: ConfigService<AppConfig>,
   ): EmailServiceInterface => {
-    const useMock = configService.get('dev.mock.email', {
+    const useMock = configService.get('email.mock', {
       infer: true,
     });
     if (useMock) {

--- a/backend/src/core/keys/apiKeys.module.ts
+++ b/backend/src/core/keys/apiKeys.module.ts
@@ -12,13 +12,10 @@ const apiKeysFactory = {
   useFactory: (
     configService: ConfigService<AppConfig>,
   ): ApiKeysProvisioningServiceInterface => {
-    const useKeysServiceMock = configService.get(
-      'dev.mock.rpcProvisioningService',
-      {
-        infer: true,
-      },
-    );
-    if (useKeysServiceMock) {
+    const rpcProvisioningService = configService.get('rpcProvisioningService', {
+      infer: true,
+    })!;
+    if (rpcProvisioningService.mock) {
       console.log('MOCKING KEYS SERVICE');
       return new ApiKeysMockProvisioningService();
     }

--- a/backend/src/core/keys/provisioning.service.ts
+++ b/backend/src/core/keys/provisioning.service.ts
@@ -22,9 +22,17 @@ export class ApiKeysProvisioningService
   private secretClient: SecretApi;
 
   constructor(private config: ConfigService<AppConfig>) {
+    const rpcProvisioningService = this.config.get('rpcProvisioningService', {
+      infer: true,
+    })!;
+    if (rpcProvisioningService.mock) {
+      throw new Error(
+        'Unexpected mock rpcProvisioningService in an actual service!',
+      );
+    }
     const configuration: Configuration = {
-      apiKey: this.config.get('rpcProvisioningService.apiKey', { infer: true }),
-      basePath: this.config.get('rpcProvisioningService.url', { infer: true }),
+      apiKey: rpcProvisioningService.apiKey,
+      basePath: rpcProvisioningService.url,
     };
 
     this.consumerClient = new ConsumerApi(configuration);

--- a/backend/src/modules/alerts/alerts.controller.ts
+++ b/backend/src/modules/alerts/alerts.controller.ts
@@ -41,17 +41,16 @@ import { Api } from '@pc/common/types/api';
 
 @Controller('alerts')
 export class AlertsController {
-  private tgSecret: string;
-  private tgEnableWebhook: boolean;
+  private tgSecret?: string;
   constructor(
     private config: ConfigService<AppConfig>,
     private readonly alertsService: AlertsService,
     private readonly telegramService: TelegramService,
   ) {
-    this.tgSecret = this.config.get('alerts.telegram.secret', { infer: true })!;
-    this.tgEnableWebhook = this.config.get('alerts.telegram.enableWebhook', {
+    const telegramOptions = this.config.get('alerts.telegram', {
       infer: true,
-    })!;
+    });
+    this.tgSecret = telegramOptions?.secret;
   }
 
   @Post('createAlert')
@@ -339,7 +338,7 @@ export class AlertsController {
     @Headers('X-Telegram-Bot-Api-Secret-Token') secret: string,
     @Body() body: Api.Mutation.Input<'/alerts/telegramWebhook'>,
   ): Promise<Api.Mutation.Output<'/alerts/telegramWebhook'>> {
-    if (!this.tgEnableWebhook) {
+    if (!this.tgSecret) {
       throw new ForbiddenException();
     }
 

--- a/backend/src/modules/alerts/alerts.service.ts
+++ b/backend/src/modules/alerts/alerts.service.ts
@@ -79,12 +79,8 @@ export class AlertsService {
     this.emailTokenExpiryMin = this.config.get('alerts.email.tokenExpiryMin', {
       infer: true,
     })!;
-    this.telegramTokenExpiryMin = this.config.get(
-      'alerts.telegram.tokenExpiryMin',
-      {
-        infer: true,
-      },
-    )!;
+    const telegram = this.config.get('alerts.telegram', { infer: true })!;
+    this.telegramTokenExpiryMin = telegram?.tokenExpiryMin || 0;
     this.contractAddressValidationEnabled = this.config.get(
       'featureEnabled.alerts.contractAddressValidation',
       { infer: true },

--- a/backend/src/modules/alerts/telegram/telegram.service.ts
+++ b/backend/src/modules/alerts/telegram/telegram.service.ts
@@ -15,9 +15,10 @@ export class TelegramService {
     private config: ConfigService<AppConfig>,
     private prisma: PrismaService,
   ) {
-    const botToken = this.config.get('alerts.telegram.botToken', {
+    const telegram = this.config.get('alerts.telegram', {
       infer: true,
     });
+    const botToken = telegram?.botToken ?? '';
 
     this.botApi = axios.create({
       baseURL: `https://api.telegram.org/bot${botToken}`,


### PR DESCRIPTION
There is no way in typescript to express "if there is a property in an object, the sibling object should be of shape A, otherwise sibling object should of shape B".
I refactored a few of config expressions to make it possible so we don't have to write complicated validation code in `zod`.