### PR TITLE
Refactor: split account balance num / percent

### DIFF
--- a/backend/src/modules/alerts/alerts.service.ts
+++ b/backend/src/modules/alerts/alerts.service.ts
@@ -169,7 +169,10 @@ export class AlertsService {
       ...alert,
       name: alert.name || defaultName,
     };
-    const matchingRule = this.ruleSerializer.toAcctBalJson(rule);
+    const matchingRule =
+      rule.type === 'ACCT_BAL_NUM'
+        ? this.ruleSerializer.toAcctBalNumJson(rule)
+        : this.ruleSerializer.toAcctBalPctJson(rule);
 
     return this.createAlertRuleWithContract(user, alert, rule, matchingRule);
   }

--- a/backend/src/modules/alerts/dto.spec.ts
+++ b/backend/src/modules/alerts/dto.spec.ts
@@ -1,10 +1,11 @@
+import { Api } from '@pc/common/types/api';
 import { CreateAlertSchema } from './dto';
 
 const contract = 'pagoda.near';
 const projectSlug = '123xyz';
 const environmentSubId = 1;
 
-test.each([
+const validSchemas: Api.Mutation.Input<'/alerts/createAlert'>[] = [
   { projectSlug, environmentSubId, rule: { type: 'TX_SUCCESS', contract } },
   { projectSlug, environmentSubId, rule: { type: 'TX_FAILURE', contract } },
   {
@@ -33,7 +34,7 @@ test.each([
     rule: {
       type: 'ACCT_BAL_NUM',
       contract,
-      from: null,
+      from: undefined,
       to: '34028236692463463374607000000',
     },
   },
@@ -44,7 +45,7 @@ test.each([
       type: 'ACCT_BAL_NUM',
       contract,
       from: '340283463374607000000',
-      to: null,
+      to: undefined,
     },
   },
   {
@@ -53,8 +54,8 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: '10',
-      to: null,
+      from: 10,
+      to: undefined,
     },
   },
   {
@@ -63,8 +64,8 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: null,
-      to: '100',
+      from: undefined,
+      to: 100,
     },
   },
   {
@@ -83,8 +84,8 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: '0',
-      to: '0',
+      from: 0,
+      to: 0,
     },
   },
   {
@@ -93,7 +94,7 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: '0',
+      from: 0,
     },
   },
   {
@@ -102,24 +103,25 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      to: '0',
+      to: 0,
     },
   },
-])('%o should be valid', (input) => {
+];
+
+test.each(validSchemas)('%o should be valid', (input) => {
   const result = CreateAlertSchema.validate(input);
   expect(result.error).toBeUndefined();
 });
 
-test.each([
-  { projectSlug, environmentSubId, rule: { type: 'INCORRECT', contract } },
+const invalidSchemas: Api.Mutation.Input<'/alerts/createAlert'>[] = [
   {
     projectSlug,
     environmentSubId,
     rule: {
       type: 'ACCT_BAL_NUM',
       contract,
-      from: null,
-      to: null,
+      from: undefined,
+      to: undefined,
     },
   },
   {
@@ -137,7 +139,7 @@ test.each([
       type: 'ACCT_BAL_NUM',
       contract,
       from: '-1',
-      to: null,
+      to: undefined,
     },
   },
   {
@@ -157,7 +159,7 @@ test.each([
       type: 'ACCT_BAL_NUM',
       contract,
       from: '340282366920938463463374607431768211456',
-      to: null,
+      to: undefined,
     },
   },
   {
@@ -166,7 +168,7 @@ test.each([
     rule: {
       type: 'ACCT_BAL_NUM',
       contract,
-      from: null,
+      from: undefined,
       to: '340282366920938463463374607431768211456',
     },
   },
@@ -176,8 +178,8 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: null,
-      to: null,
+      from: undefined,
+      to: undefined,
     },
   },
   {
@@ -186,8 +188,8 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: '101',
-      to: null,
+      from: 101,
+      to: undefined,
     },
   },
   {
@@ -196,8 +198,8 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: '0',
-      to: '101',
+      from: 0,
+      to: 101,
     },
   },
   {
@@ -206,11 +208,13 @@ test.each([
     rule: {
       type: 'ACCT_BAL_PCT',
       contract,
-      from: '-1',
-      to: null,
+      from: -1,
+      to: undefined,
     },
   },
-])('%o should throw errors', (input) => {
+];
+
+test.each(invalidSchemas)('%o should throw errors', (input) => {
   const result = CreateAlertSchema.validate(input);
   expect(result.error).toBeDefined();
 });

--- a/backend/src/modules/alerts/dto.ts
+++ b/backend/src/modules/alerts/dto.ts
@@ -25,11 +25,17 @@ const EventRuleSchema = Joi.object<Alerts.EventRule, true>({
 });
 
 const validateRange = (value, { original: rule }) => {
-  if (!rule.from && !rule.to) {
+  if (rule.from === undefined && rule.to === undefined) {
     throw Error('"rule.from" or "rule.to" is required');
   }
-  if (rule.from && rule.to && BigInt(rule.from) > BigInt(rule.to)) {
-    throw Error('"rule.from" must be less than or equal to "rule.to"');
+  if (rule.from !== undefined && rule.to !== undefined) {
+    if (typeof rule.from === 'number' && typeof rule.to === 'number') {
+      if (rule.from > rule.to) {
+        throw Error('"rule.from" must be less than or equal to "rule.to"');
+      }
+    } else if (BigInt(rule.from) > BigInt(rule.to)) {
+      throw Error('"rule.from" must be less than or equal to "rule.to"');
+    }
   }
   return value;
 };
@@ -37,14 +43,8 @@ const validateRange = (value, { original: rule }) => {
 const AcctBalPctRuleSchema = Joi.object<Alerts.AcctBalPctRule, true>({
   type: Joi.string().valid('ACCT_BAL_PCT'),
   contract: Joi.string().required(),
-  from: Joi.string()
-    .empty(null)
-    .optional()
-    .regex(/^0$|^[1-9][0-9]?$|^100$/), // Percentage between 0 and 100
-  to: Joi.string()
-    .empty(null)
-    .optional()
-    .regex(/^0$|^[1-9][0-9]?$|^100$/), // Percentage between 0 and 100
+  from: Joi.number().integer().min(0).max(100).optional(),
+  to: Joi.number().integer().min(0).max(100).optional(),
 }).custom(validateRange, 'Validating range');
 
 const validateYoctonearAmount = (value, _) => {
@@ -62,7 +62,7 @@ const AcctBalNumRuleSchema = Joi.object<Alerts.AcctBalNumRule, true>({
   type: Joi.string().valid('ACCT_BAL_NUM'),
   contract: Joi.string().required(),
   from: Joi.string()
-    .empty(null)
+    .empty(undefined)
     .optional()
     .regex(/^0$|^[1-9][0-9]*$/)
     .custom(
@@ -70,7 +70,7 @@ const AcctBalNumRuleSchema = Joi.object<Alerts.AcctBalNumRule, true>({
       'Validating proper value of Yoctonear amount',
     ),
   to: Joi.string()
-    .empty(null)
+    .empty(undefined)
     .optional()
     .regex(/^0$|^[1-9][0-9]*$/)
     .custom(

--- a/backend/src/modules/alerts/serde/rule-deserializer/rule-deserializer.service.ts
+++ b/backend/src/modules/alerts/serde/rule-deserializer/rule-deserializer.service.ts
@@ -62,8 +62,14 @@ export class RuleDeserializerService {
     return {
       type: 'ACCT_BAL_PCT',
       contract: rule.affected_account_id,
-      from: rule.comparator_range.from,
-      to: rule.comparator_range.to,
+      from:
+        rule.comparator_range.from === null
+          ? undefined
+          : Number(rule.comparator_range.from),
+      to:
+        rule.comparator_range.to === null
+          ? undefined
+          : Number(rule.comparator_range.to),
     };
   }
 
@@ -71,8 +77,14 @@ export class RuleDeserializerService {
     return {
       type: 'ACCT_BAL_NUM',
       contract: rule.affected_account_id,
-      from: rule.comparator_range.from,
-      to: rule.comparator_range.to,
+      from:
+        rule.comparator_range.from === null
+          ? undefined
+          : rule.comparator_range.from,
+      to:
+        rule.comparator_range.to === null
+          ? undefined
+          : rule.comparator_range.to,
     };
   }
 }

--- a/backend/src/modules/alerts/serde/rule-serializer/rule-serializer.service.spec.ts
+++ b/backend/src/modules/alerts/serde/rule-serializer/rule-serializer.service.spec.ts
@@ -75,7 +75,7 @@ describe('RuleSerializerService', () => {
         type: 'ACCT_BAL_NUM' as const,
         contract: 'pagoda.near',
         from: '0',
-        to: null,
+        to: undefined,
       },
       expected: {
         rule: 'STATE_CHANGE_ACCOUNT_BALANCE',
@@ -92,7 +92,7 @@ describe('RuleSerializerService', () => {
         type: 'ACCT_BAL_NUM' as const,
         contract: 'pagoda.near',
         to: '330',
-        from: null,
+        from: undefined,
       },
       expected: {
         rule: 'STATE_CHANGE_ACCOUNT_BALANCE',
@@ -122,16 +122,16 @@ describe('RuleSerializerService', () => {
       },
     },
   ])('should serialize account balance num rule', ({ dto, expected }) => {
-    expect(service.toAcctBalJson(dto)).toStrictEqual(expected);
+    expect(service.toAcctBalNumJson(dto)).toStrictEqual(expected);
   });
 
   it('should serialize account balance pct rule', () => {
     expect(
-      service.toAcctBalJson({
+      service.toAcctBalPctJson({
         type: 'ACCT_BAL_PCT',
         contract: 'pagoda.near',
-        from: '0',
-        to: null,
+        from: 0,
+        to: undefined,
       }),
     ).toStrictEqual({
       rule: 'STATE_CHANGE_ACCOUNT_BALANCE',
@@ -146,22 +146,22 @@ describe('RuleSerializerService', () => {
 
   it('should fail to serialize account balance rule with invalid range', () => {
     expect(() => {
-      service.toAcctBalJson({
+      service.toAcctBalPctJson({
         type: 'ACCT_BAL_PCT',
         contract: 'pagoda.near',
-        from: null,
-        to: null,
+        from: undefined,
+        to: undefined,
       });
     }).toThrow('Invalid range');
   });
 
   it('should fail to serialize account balance rule with from > to', () => {
     expect(() => {
-      service.toAcctBalJson({
+      service.toAcctBalPctJson({
         type: 'ACCT_BAL_PCT',
         contract: 'pagoda.near',
-        from: '3',
-        to: '0',
+        from: 3,
+        to: 0,
       });
     }).toThrow('Invalid range');
   });

--- a/backend/src/modules/alerts/serde/rule-serializer/rule-serializer.service.ts
+++ b/backend/src/modules/alerts/serde/rule-serializer/rule-serializer.service.ts
@@ -3,7 +3,6 @@ import { Alerts } from '@pc/common/types/alerts';
 import { VError } from 'verror';
 import {
   AcctBalMatchingRule,
-  ComparatorKind,
   EventMatchingRule,
   FnCallMatchingRule,
   TxMatchingRule,
@@ -46,36 +45,51 @@ export class RuleSerializerService {
     };
   }
 
-  toAcctBalJson(
-    rule: Alerts.AcctBalPctRule | Alerts.AcctBalNumRule,
-  ): AcctBalMatchingRule {
+  toAcctBalNumJson(rule: Alerts.AcctBalNumRule): AcctBalMatchingRule {
     if (!rule.from && !rule.to) {
       throw new VError('Invalid range');
     }
 
-    if (rule.from && rule.to && BigInt(rule.from) > BigInt(rule.to)) {
+    if (
+      rule.from !== undefined &&
+      rule.to !== undefined &&
+      BigInt(rule.from) > BigInt(rule.to)
+    ) {
       throw new VError('Invalid range');
     }
 
     return {
       rule: 'STATE_CHANGE_ACCOUNT_BALANCE',
       affected_account_id: rule.contract,
-      comparator_kind: this.ruleTypeToComparatorKind(rule.type),
+      comparator_kind: 'RELATIVE_YOCTONEAR_AMOUNT',
       comparator_range: {
-        from: rule.from,
-        to: rule.to,
+        from: rule.from === undefined ? null : rule.from.toString(),
+        to: rule.to === undefined ? null : rule.to.toString(),
       },
     };
   }
 
-  private ruleTypeToComparatorKind(
-    ruleType: 'ACCT_BAL_NUM' | 'ACCT_BAL_PCT',
-  ): ComparatorKind {
-    switch (ruleType) {
-      case 'ACCT_BAL_NUM':
-        return 'RELATIVE_YOCTONEAR_AMOUNT';
-      case 'ACCT_BAL_PCT':
-        return 'RELATIVE_PERCENTAGE_AMOUNT';
+  toAcctBalPctJson(rule: Alerts.AcctBalPctRule): AcctBalMatchingRule {
+    if (rule.from === undefined && rule.to === undefined) {
+      throw new VError('Invalid range');
     }
+
+    if (
+      rule.from !== undefined &&
+      rule.to !== undefined &&
+      rule.from > rule.to
+    ) {
+      throw new VError('Invalid range');
+    }
+
+    return {
+      rule: 'STATE_CHANGE_ACCOUNT_BALANCE',
+      affected_account_id: rule.contract,
+      comparator_kind: 'RELATIVE_PERCENTAGE_AMOUNT',
+      comparator_range: {
+        from: rule.from === undefined ? null : rule.from.toString(),
+        to: rule.to === undefined ? null : rule.to.toString(),
+      },
+    };
   }
 }

--- a/common/types/alerts/alerts.schema.ts
+++ b/common/types/alerts/alerts.schema.ts
@@ -35,14 +35,14 @@ export type EventRule = {
 export type AcctBalPctRule = {
   type: 'ACCT_BAL_PCT';
   contract: string;
-  from: string | null;
-  to: string | null;
+  from?: number;
+  to?: number;
 };
 export type AcctBalNumRule = {
   type: 'ACCT_BAL_NUM';
   contract: string;
-  from: string | null;
-  to: string | null;
+  from?: string;
+  to?: string;
 };
 
 export type Rule =

--- a/frontend/pages/alerts/edit-alert/[alertId].tsx
+++ b/frontend/pages/alerts/edit-alert/[alertId].tsx
@@ -490,10 +490,10 @@ function AlertSettings({ alert }: { alert: Alert }) {
   return null;
 }
 
-function returnAmountComparator(from: string | null, to: string | null) {
+function returnAmountComparator<T extends string | number>(from?: T, to?: T) {
   if (from === to) return amountComparators.EQ;
-  if (from === null) return amountComparators.LTE;
-  if (to === null) return amountComparators.GTE;
+  if (from === undefined) return amountComparators.LTE;
+  if (to === undefined) return amountComparators.GTE;
   return amountComparators.RANGE;
 }
 

--- a/frontend/pages/alerts/new-alert.tsx
+++ b/frontend/pages/alerts/new-alert.tsx
@@ -49,8 +49,8 @@ interface FormData {
     to: string;
   };
   acctBalPctRule?: {
-    from: string;
-    to: string;
+    from: number;
+    to: number;
   };
   eventRule?: {
     standard: string;
@@ -426,7 +426,7 @@ const NewAlert: NextPageWithLayout = () => {
                             form.clearErrors('acctBalPctRule.to');
                           }}
                           {...form.register('acctBalPctRule.from', {
-                            setValueAs: (value) => sanitizeNumber(value),
+                            setValueAs: (value) => Number(sanitizeNumber(value)),
                             required: 'Please enter a percentage',
                             validate: {
                               maxValue: (value) => Number(value) <= 100 || 'Must be 100 or less',
@@ -446,7 +446,7 @@ const NewAlert: NextPageWithLayout = () => {
                             isNumber
                             onInput={numberInputHandler}
                             {...form.register('acctBalPctRule.to', {
-                              setValueAs: (value) => sanitizeNumber(value),
+                              setValueAs: (value) => Number(sanitizeNumber(value)),
                               required: 'Please enter a percentage',
                               validate: {
                                 minValue: (value) =>
@@ -650,7 +650,7 @@ function returnAcctBalNumBody(comparator: Alerts.Comparator, { from, to }: { fro
   return returnAcctBalBody(comparator, { from, to });
 }
 
-function returnAcctBalBody(comparator: Alerts.Comparator, { from, to }: { from: string; to: string }) {
+function returnAcctBalBody<T extends string | number>(comparator: Alerts.Comparator, { from, to }: { from: T; to: T }) {
   switch (comparator) {
     case 'EQ':
       return {
@@ -660,11 +660,11 @@ function returnAcctBalBody(comparator: Alerts.Comparator, { from, to }: { from: 
     case 'GTE':
       return {
         from,
-        to: null,
+        to: undefined,
       };
     case 'LTE':
       return {
-        from: null,
+        from: undefined,
         to: from,
       };
     case 'RANGE':


### PR DESCRIPTION
This is an optional one.
I noticed we use percents in one of the alert rules, why don't we use numbers for it?
Using it makes more sense semantically as well as helps out discriminating the values when you stumble upon them.
Also, I changed `null` to `undefined` to reduce data passed by a bit.