### PR TITLE
Refactor: flavored types

### DIFF
--- a/backend/src/core/explorer/actions.ts
+++ b/backend/src/core/explorer/actions.ts
@@ -117,9 +117,8 @@ export const mapDatabaseActionToAction = (
               nonce: action.args.access_key.nonce,
               permission: {
                 type: 'functionCall',
-                contractId:
-                  action.args.access_key.permission.permission_details
-                    .receiver_id,
+                contractId: action.args.access_key.permission.permission_details
+                  .receiver_id as Explorer.AccountId,
                 methodNames:
                   action.args.access_key.permission.permission_details
                     .method_names,
@@ -135,7 +134,7 @@ export const mapDatabaseActionToAction = (
       return {
         kind: 'deleteAccount',
         args: {
-          beneficiaryId: action.args.beneficiary_id,
+          beneficiaryId: action.args.beneficiary_id as Explorer.AccountId,
         },
       };
     case 'DELETE_KEY':
@@ -159,7 +158,7 @@ export const mapDatabaseActionToAction = (
           methodName: action.args.method_name,
           args: action.args.args_base64,
           gas: action.args.gas,
-          deposit: action.args.deposit,
+          deposit: action.args.deposit as Explorer.YoctoNear,
         },
       };
     case 'STAKE':
@@ -167,14 +166,14 @@ export const mapDatabaseActionToAction = (
         kind: 'stake',
         args: {
           publicKey: action.args.public_key,
-          stake: action.args.stake,
+          stake: action.args.stake as Explorer.YoctoNear,
         },
       };
     case 'TRANSFER':
       return {
         kind: 'transfer',
         args: {
-          deposit: action.args.deposit,
+          deposit: action.args.deposit as Explorer.YoctoNear,
         },
       };
   }
@@ -201,7 +200,7 @@ export const mapRpcActionToAction = (
       args: {
         methodName: rpcAction.FunctionCall.method_name,
         args: rpcAction.FunctionCall.args,
-        deposit: rpcAction.FunctionCall.deposit,
+        deposit: rpcAction.FunctionCall.deposit as Explorer.YoctoNear,
         gas: rpcAction.FunctionCall.gas,
       },
     };
@@ -209,7 +208,9 @@ export const mapRpcActionToAction = (
   if ('Transfer' in rpcAction) {
     return {
       kind: 'transfer',
-      args: rpcAction.Transfer,
+      args: {
+        deposit: rpcAction.Transfer.deposit as Explorer.YoctoNear,
+      },
     };
   }
   if ('Stake' in rpcAction) {
@@ -217,7 +218,7 @@ export const mapRpcActionToAction = (
       kind: 'stake',
       args: {
         publicKey: rpcAction.Stake.public_key,
-        stake: rpcAction.Stake.stake,
+        stake: rpcAction.Stake.stake as Explorer.YoctoNear,
       },
     };
   }
@@ -235,9 +236,8 @@ export const mapRpcActionToAction = (
                 }
               : {
                   type: 'functionCall',
-                  contractId:
-                    rpcAction.AddKey.access_key.permission.FunctionCall
-                      .receiver_id,
+                  contractId: rpcAction.AddKey.access_key.permission
+                    .FunctionCall.receiver_id as Explorer.AccountId,
                   methodNames:
                     rpcAction.AddKey.access_key.permission.FunctionCall
                       .method_names,
@@ -257,7 +257,8 @@ export const mapRpcActionToAction = (
   return {
     kind: 'deleteAccount',
     args: {
-      beneficiaryId: rpcAction.DeleteAccount.beneficiary_id,
+      beneficiaryId: rpcAction.DeleteAccount
+        .beneficiary_id as Explorer.AccountId,
     },
   };
 };

--- a/backend/src/core/explorer/indexer.service.ts
+++ b/backend/src/core/explorer/indexer.service.ts
@@ -234,7 +234,7 @@ export class IndexerService {
     return await this.createTransactionsList(accountTxList, net);
   }
 
-  async fetchRecentTransactions(accounts: string[], net: Net) {
+  async fetchRecentTransactions(accounts: Explorer.AccountId[], net: Net) {
     const promises: Promise<Explorer.Old.Transaction[] | undefined>[] = [];
 
     for (const account of accounts) {
@@ -256,7 +256,7 @@ export class IndexerService {
     const results = await Promise.allSettled(promises);
     // console.log(results);
     let mergedTransactions: (Explorer.Old.Transaction & {
-      sourceContract: string;
+      sourceContract: Explorer.AccountId;
     })[] = [];
 
     for (let i = 0; i < results.length; i++) {

--- a/backend/src/core/explorer/receipt-status.ts
+++ b/backend/src/core/explorer/receipt-status.ts
@@ -10,7 +10,7 @@ const mapRpcCompilationError = (
   if ('CodeDoesNotExist' in error) {
     return {
       type: 'codeDoesNotExist',
-      accountId: error.CodeDoesNotExist.account_id,
+      accountId: error.CodeDoesNotExist.account_id as Explorer.AccountId,
     };
   }
   if ('PrepareError' in error) {
@@ -87,25 +87,25 @@ const mapRpcNewReceiptValidationError = (
   if ('InvalidPredecessorId' in error) {
     return {
       type: 'invalidPredecessorId',
-      accountId: error.InvalidPredecessorId.account_id,
+      accountId: error.InvalidPredecessorId.account_id as Explorer.AccountId,
     };
   }
   if ('InvalidReceiverId' in error) {
     return {
       type: 'invalidReceiverId',
-      accountId: error.InvalidReceiverId.account_id,
+      accountId: error.InvalidReceiverId.account_id as Explorer.AccountId,
     };
   }
   if ('InvalidSignerId' in error) {
     return {
       type: 'invalidSignerId',
-      accountId: error.InvalidSignerId.account_id,
+      accountId: error.InvalidSignerId.account_id as Explorer.AccountId,
     };
   }
   if ('InvalidDataReceiverId' in error) {
     return {
       type: 'invalidDataReceiverId',
-      accountId: error.InvalidDataReceiverId.account_id,
+      accountId: error.InvalidDataReceiverId.account_id as Explorer.AccountId,
     };
   }
   if ('ReturnedValueLengthExceeded' in error) {
@@ -161,13 +161,13 @@ const mapRpcReceiptInvalidTxError = (
   if ('InvalidSignerId' in error) {
     return {
       type: 'invalidSignerId',
-      signerId: error.InvalidSignerId.signer_id,
+      signerId: error.InvalidSignerId.signer_id as Explorer.AccountId,
     };
   }
   if ('SignerDoesNotExist' in error) {
     return {
       type: 'signerDoesNotExist',
-      signerId: error.SignerDoesNotExist.signer_id,
+      signerId: error.SignerDoesNotExist.signer_id as Explorer.AccountId,
     };
   }
   if ('InvalidNonce' in error) {
@@ -187,7 +187,7 @@ const mapRpcReceiptInvalidTxError = (
   if ('InvalidReceiverId' in error) {
     return {
       type: 'invalidReceiverId',
-      receiverId: error.InvalidReceiverId.receiver_id,
+      receiverId: error.InvalidReceiverId.receiver_id as Explorer.AccountId,
     };
   }
   if ('InvalidSignature' in error) {
@@ -198,16 +198,16 @@ const mapRpcReceiptInvalidTxError = (
   if ('NotEnoughBalance' in error) {
     return {
       type: 'notEnoughBalance',
-      signerId: error.NotEnoughBalance.signer_id,
-      balance: error.NotEnoughBalance.balance,
-      cost: error.NotEnoughBalance.cost,
+      signerId: error.NotEnoughBalance.signer_id as Explorer.AccountId,
+      balance: error.NotEnoughBalance.balance as Explorer.YoctoNear,
+      cost: error.NotEnoughBalance.cost as Explorer.YoctoNear,
     };
   }
   if ('LackBalanceForState' in error) {
     return {
       type: 'lackBalanceForState',
-      signerId: error.LackBalanceForState.signer_id,
-      amount: error.LackBalanceForState.amount,
+      signerId: error.LackBalanceForState.signer_id as Explorer.AccountId,
+      amount: error.LackBalanceForState.amount as Explorer.YoctoNear,
     };
   }
   if ('CostOverflow' in error) {
@@ -247,86 +247,89 @@ const mapRpcReceiptActionError = (
   if ('AccountAlreadyExists' in kind) {
     return {
       type: 'accountAlreadyExists',
-      accountId: kind.AccountAlreadyExists.account_id,
+      accountId: kind.AccountAlreadyExists.account_id as Explorer.AccountId,
     };
   }
   if ('AccountDoesNotExist' in kind) {
     return {
       type: 'accountDoesNotExist',
-      accountId: kind.AccountDoesNotExist.account_id,
+      accountId: kind.AccountDoesNotExist.account_id as Explorer.AccountId,
     };
   }
   if ('CreateAccountOnlyByRegistrar' in kind) {
     return {
       type: 'createAccountOnlyByRegistrar',
-      accountId: kind.CreateAccountOnlyByRegistrar.account_id,
-      registrarAccountId:
-        kind.CreateAccountOnlyByRegistrar.registrar_account_id,
-      predecessorId: kind.CreateAccountOnlyByRegistrar.predecessor_id,
+      accountId: kind.CreateAccountOnlyByRegistrar
+        .account_id as Explorer.AccountId,
+      registrarAccountId: kind.CreateAccountOnlyByRegistrar
+        .registrar_account_id as Explorer.AccountId,
+      predecessorId: kind.CreateAccountOnlyByRegistrar
+        .predecessor_id as Explorer.AccountId,
     };
   }
   if ('CreateAccountNotAllowed' in kind) {
     return {
       type: 'createAccountNotAllowed',
-      accountId: kind.CreateAccountNotAllowed.account_id,
-      predecessorId: kind.CreateAccountNotAllowed.predecessor_id,
+      accountId: kind.CreateAccountNotAllowed.account_id as Explorer.AccountId,
+      predecessorId: kind.CreateAccountNotAllowed
+        .predecessor_id as Explorer.AccountId,
     };
   }
   if ('ActorNoPermission' in kind) {
     return {
       type: 'actorNoPermission',
-      accountId: kind.ActorNoPermission.account_id,
-      actorId: kind.ActorNoPermission.actor_id,
+      accountId: kind.ActorNoPermission.account_id as Explorer.AccountId,
+      actorId: kind.ActorNoPermission.actor_id as Explorer.AccountId,
     };
   }
   if ('DeleteKeyDoesNotExist' in kind) {
     return {
       type: 'deleteKeyDoesNotExist',
-      accountId: kind.DeleteKeyDoesNotExist.account_id,
+      accountId: kind.DeleteKeyDoesNotExist.account_id as Explorer.AccountId,
       publicKey: kind.DeleteKeyDoesNotExist.public_key,
     };
   }
   if ('AddKeyAlreadyExists' in kind) {
     return {
       type: 'addKeyAlreadyExists',
-      accountId: kind.AddKeyAlreadyExists.account_id,
+      accountId: kind.AddKeyAlreadyExists.account_id as Explorer.AccountId,
       publicKey: kind.AddKeyAlreadyExists.public_key,
     };
   }
   if ('DeleteAccountStaking' in kind) {
     return {
       type: 'deleteAccountStaking',
-      accountId: kind.DeleteAccountStaking.account_id,
+      accountId: kind.DeleteAccountStaking.account_id as Explorer.AccountId,
     };
   }
   if ('LackBalanceForState' in kind) {
     return {
       type: 'lackBalanceForState',
-      accountId: kind.LackBalanceForState.account_id,
-      amount: kind.LackBalanceForState.amount,
+      accountId: kind.LackBalanceForState.account_id as Explorer.AccountId,
+      amount: kind.LackBalanceForState.amount as Explorer.YoctoNear,
     };
   }
   if ('TriesToUnstake' in kind) {
     return {
       type: 'triesToUnstake',
-      accountId: kind.TriesToUnstake.account_id,
+      accountId: kind.TriesToUnstake.account_id as Explorer.AccountId,
     };
   }
   if ('TriesToStake' in kind) {
     return {
       type: 'triesToStake',
-      accountId: kind.TriesToStake.account_id,
-      stake: kind.TriesToStake.stake,
-      locked: kind.TriesToStake.locked,
-      balance: kind.TriesToStake.balance,
+      accountId: kind.TriesToStake.account_id as Explorer.AccountId,
+      stake: kind.TriesToStake.stake as Explorer.YoctoNear,
+      locked: kind.TriesToStake.locked as Explorer.YoctoNear,
+      balance: kind.TriesToStake.balance as Explorer.YoctoNear,
     };
   }
   if ('InsufficientStake' in kind) {
     return {
       type: 'insufficientStake',
-      accountId: kind.InsufficientStake.account_id,
-      stake: kind.InsufficientStake.stake,
-      minimumStake: kind.InsufficientStake.minimum_stake,
+      accountId: kind.InsufficientStake.account_id as Explorer.AccountId,
+      stake: kind.InsufficientStake.stake as Explorer.YoctoNear,
+      minimumStake: kind.InsufficientStake.minimum_stake as Explorer.YoctoNear,
     };
   }
   if ('FunctionCallError' in kind) {
@@ -344,13 +347,15 @@ const mapRpcReceiptActionError = (
   if ('OnlyImplicitAccountCreationAllowed' in kind) {
     return {
       type: 'onlyImplicitAccountCreationAllowed',
-      accountId: kind.OnlyImplicitAccountCreationAllowed.account_id,
+      accountId: kind.OnlyImplicitAccountCreationAllowed
+        .account_id as Explorer.AccountId,
     };
   }
   if ('DeleteAccountWithLargeState' in kind) {
     return {
       type: 'deleteAccountWithLargeState',
-      accountId: kind.DeleteAccountWithLargeState.account_id,
+      accountId: kind.DeleteAccountWithLargeState
+        .account_id as Explorer.AccountId,
     };
   }
   return UNKNOWN_ERROR;
@@ -363,7 +368,10 @@ export const mapRpcReceiptStatus = (
     return { type: 'successValue', value: status.SuccessValue };
   }
   if ('SuccessReceiptId' in status) {
-    return { type: 'successReceiptId', receiptId: status.SuccessReceiptId };
+    return {
+      type: 'successReceiptId',
+      receiptId: status.SuccessReceiptId as Explorer.ReceiptId,
+    };
   }
   if ('Failure' in status) {
     return { type: 'failure', error: mapRpcReceiptError(status.Failure) };

--- a/backend/src/core/keys/apiKeys.service.ts
+++ b/backend/src/core/keys/apiKeys.service.ts
@@ -4,6 +4,7 @@ import { customAlphabet } from 'nanoid';
 import { VError } from 'verror';
 import { PrismaService } from '../prisma.service';
 import { ApiKeysProvisioningService } from './provisioning.service';
+import { Projects } from '@pc/common/types/core';
 
 const nanoid = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 20);
 
@@ -16,11 +17,11 @@ export class ApiKeysService {
 
   async generateKey(
     userId: User['id'],
-    orgSlug: string,
-    projectSlug: string,
+    orgSlug: Projects.OrgSlug,
+    projectSlug: Projects.ProjectSlug,
     usersDescription?: string,
   ) {
-    const slug = nanoid();
+    const slug = nanoid() as Projects.ApiKeySlug;
     const description = usersDescription ? usersDescription : 'default';
     const kongConsumerName = await this.getKongConsumerName(orgSlug);
 
@@ -75,7 +76,7 @@ export class ApiKeysService {
     }
   }
 
-  async rotateKey(userId: User['id'], slug: string) {
+  async rotateKey(userId: User['id'], slug: Projects.ApiKeySlug) {
     let keyDetails;
     try {
       keyDetails = await this.getKeyDetails(slug);
@@ -112,7 +113,11 @@ export class ApiKeysService {
     }
   }
 
-  async deleteKey(userId: User['id'], orgSlug: string, slug: string) {
+  async deleteKey(
+    userId: User['id'],
+    orgSlug: Projects.OrgSlug,
+    slug: Projects.ApiKeySlug,
+  ) {
     const kongConsumerName = await this.getKongConsumerName(orgSlug);
 
     if (!kongConsumerName) {
@@ -160,7 +165,7 @@ export class ApiKeysService {
     }
   }
 
-  async getKeys(projectSlug: string) {
+  async getKeys(projectSlug: Projects.ProjectSlug) {
     try {
       const projectKeySlugs = await this.prisma.apiKey.findMany({
         where: {
@@ -184,7 +189,7 @@ export class ApiKeysService {
 
       const keys: {
         id: number;
-        keySlug: string;
+        keySlug: Projects.ApiKeySlug;
         description: string;
         key: string;
         kongConsumerName: string;
@@ -214,7 +219,7 @@ export class ApiKeysService {
     }
   }
 
-  async getKey(slug: string) {
+  async getKey(slug: Projects.ApiKeySlug) {
     let keyDetails;
     try {
       keyDetails = await this.prisma.apiKey.findUnique({
@@ -245,7 +250,7 @@ export class ApiKeysService {
     }
   }
 
-  async deleteOrg(userId: User['id'], orgSlug: string) {
+  async deleteOrg(userId: User['id'], orgSlug: Projects.OrgSlug) {
     const kongConsumerName = await this.getKongConsumerName(orgSlug);
 
     if (!kongConsumerName) {
@@ -275,7 +280,7 @@ export class ApiKeysService {
     }
   }
 
-  async getKeyDetails(slug: string) {
+  async getKeyDetails(slug: Projects.ApiKeySlug) {
     let keyDetails;
     try {
       keyDetails = await this.prisma.apiKey.findUnique({
@@ -294,7 +299,10 @@ export class ApiKeysService {
     return keyDetails;
   }
 
-  async deleteProjectKeys(userId: User['id'], projectSlug: string) {
+  async deleteProjectKeys(
+    userId: User['id'],
+    projectSlug: Projects.ProjectSlug,
+  ) {
     try {
       const projectKeySlugs = await this.prisma.apiKey.findMany({
         where: {
@@ -321,7 +329,10 @@ export class ApiKeysService {
     }
   }
 
-  async createOrganization(kongConsumerName: string, orgSlug: string) {
+  async createOrganization(
+    kongConsumerName: string,
+    orgSlug: Projects.OrgSlug,
+  ) {
     try {
       await this.provisioningService.createOrganization(
         kongConsumerName,
@@ -335,7 +346,7 @@ export class ApiKeysService {
     }
   }
 
-  private async getKongConsumerName(orgSlug: string) {
+  private async getKongConsumerName(orgSlug: Projects.OrgSlug) {
     try {
       const res = (await this.prisma.org.findFirst({
         where: {

--- a/backend/src/core/keys/interfaces.ts
+++ b/backend/src/core/keys/interfaces.ts
@@ -1,12 +1,13 @@
+import { Projects } from '@pc/common/types/core';
 import { Consumer } from './rpcaas-client';
 
 export interface ApiKeysProvisioningServiceInterface {
-  createOrganization(kongConsumer: string, orgSlug: string);
-  generate(kongConsumer: string, keySlug: string);
-  rotate(kongConsumer: string, keySlug: string);
-  delete(kongConsumer: string, keySlug: string);
+  createOrganization(kongConsumer: string, orgSlug: Projects.OrgSlug);
+  generate(kongConsumer: string, keySlug: Projects.ApiKeySlug);
+  rotate(kongConsumer: string, keySlug: Projects.ApiKeySlug);
+  delete(kongConsumer: string, keySlug: Projects.ApiKeySlug);
   deleteOrganization(kongConsumer: string);
-  fetch(keySlug: string): Promise<string>;
+  fetch(keySlug: Projects.ApiKeySlug): Promise<string>;
   fetchAll(kongConsumer: string): Promise<Array<string> | undefined>;
   getOrganization(kongConsumer: string): Promise<Consumer | null>;
 }

--- a/backend/src/core/keys/mock.provisioning.service.ts
+++ b/backend/src/core/keys/mock.provisioning.service.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Injectable } from '@nestjs/common';
+import { Projects } from '@pc/common/types/core';
 import { ApiKeysProvisioningServiceInterface } from './interfaces';
 import { Consumer, ConsumerRateLimitingPolicyEnum } from './rpcaas-client';
 
@@ -17,22 +18,22 @@ export class ApiKeysMockProvisioningService
       username: kongConsumer,
     };
   }
-  async createOrganization(kongConsumer: string, orgSlug: string) {
+  async createOrganization(kongConsumer: string, orgSlug: Projects.OrgSlug) {
     return;
   }
-  async generate(kongConsumer: string, keySlug: string) {
+  async generate(kongConsumer: string, keySlug: Projects.ApiKeySlug) {
     return this.MOCK_KEY;
   }
-  async rotate(kongConsumer: string, keySlug: string) {
+  async rotate(kongConsumer: string, keySlug: Projects.ApiKeySlug) {
     return this.MOCK_KEY;
   }
-  async delete(kongConsumer: string, keySlug: string) {
+  async delete(kongConsumer: string, keySlug: Projects.ApiKeySlug) {
     return;
   }
   async deleteOrganization(kongConsumer: string) {
     return;
   }
-  async fetch(keySlug: string): Promise<string> {
+  async fetch(keySlug: Projects.ApiKeySlug): Promise<string> {
     return this.MOCK_KEY;
   }
   async fetchAll(kongConsumer: string): Promise<string[]> {

--- a/backend/src/core/keys/provisioning.service.ts
+++ b/backend/src/core/keys/provisioning.service.ts
@@ -13,6 +13,7 @@ import {
   SecretBodyKongCredTypeEnum,
 } from './rpcaas-client';
 import { VError } from 'verror';
+import { Projects } from '@pc/common/types/core';
 
 @Injectable()
 export class ApiKeysProvisioningService
@@ -39,7 +40,7 @@ export class ApiKeysProvisioningService
     this.secretClient = new SecretApi(configuration);
   }
 
-  async createOrganization(kongConsumer: string, orgSlug: string) {
+  async createOrganization(kongConsumer: string, orgSlug: Projects.OrgSlug) {
     try {
       await this.createConsumer(kongConsumer, orgSlug);
     } catch (e: any) {
@@ -48,7 +49,7 @@ export class ApiKeysProvisioningService
     }
   }
 
-  async generate(kongConsumer: string, keySlug: string) {
+  async generate(kongConsumer: string, keySlug: Projects.ApiKeySlug) {
     const keyName = this.getKeyName(keySlug);
     const body: SecretBody = {
       kongCredType: SecretBodyKongCredTypeEnum.KeyAuth,
@@ -64,7 +65,7 @@ export class ApiKeysProvisioningService
     }
   }
 
-  async rotate(kongConsumer: string, keySlug: string) {
+  async rotate(kongConsumer: string, keySlug: Projects.ApiKeySlug) {
     try {
       await this.delete(kongConsumer, keySlug);
       await this.generate(kongConsumer, keySlug);
@@ -73,7 +74,7 @@ export class ApiKeysProvisioningService
     }
   }
 
-  async delete(kongConsumer: string, keySlug: string) {
+  async delete(kongConsumer: string, keySlug: Projects.ApiKeySlug) {
     try {
       await this.secretClient.deleteSecret(
         this.getConsumerName(kongConsumer),
@@ -94,7 +95,7 @@ export class ApiKeysProvisioningService
     }
   }
 
-  async fetch(keySlug: string): Promise<string> {
+  async fetch(keySlug: Projects.ApiKeySlug): Promise<string> {
     try {
       const keyName = this.getKeyName(keySlug);
       return (await this.secretClient.getSecret(keyName)).data.api_token;
@@ -124,7 +125,10 @@ export class ApiKeysProvisioningService
     }
   }
 
-  private async createConsumer(kongConsumer: string, orgSlug: string) {
+  private async createConsumer(
+    kongConsumer: string,
+    orgSlug: Projects.OrgSlug,
+  ) {
     const username = this.getConsumerName(kongConsumer);
     const consumer: Consumer = {
       custom_id: orgSlug,
@@ -143,7 +147,7 @@ export class ApiKeysProvisioningService
     return kongConsumer;
   }
 
-  private getKeyName(keySlug: string) {
+  private getKeyName(keySlug: Projects.ApiKeySlug) {
     return keySlug;
   }
 }

--- a/backend/src/core/projects/permissions.service.ts
+++ b/backend/src/core/projects/permissions.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { User, Project, Environment } from '@pc/database/clients/core';
+import { User } from '@pc/database/clients/core';
 import { PrismaService } from '../prisma.service';
 import { VError } from 'verror';
+import { Projects } from '@pc/common/types/core';
 
 @Injectable()
 export class PermissionsService {
@@ -9,8 +10,8 @@ export class PermissionsService {
 
   async checkUserProjectEnvPermission(
     userId: User['id'],
-    slug: Project['slug'],
-    subId: Environment['subId'],
+    slug: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
   ) {
     const res = await this.prisma.teamMember.findFirst({
       where: {
@@ -44,7 +45,10 @@ export class PermissionsService {
     }
   }
 
-  async checkUserProjectPermission(userId: User['id'], slug: Project['slug']) {
+  async checkUserProjectPermission(
+    userId: User['id'],
+    slug: Projects.ProjectSlug,
+  ) {
     const res = await this.prisma.teamMember.findFirst({
       where: {
         userId,
@@ -71,7 +75,10 @@ export class PermissionsService {
     }
   }
 
-  async checkUserContractPermission(userId: User['id'], slug: Project['slug']) {
+  async checkUserContractPermission(
+    userId: User['id'],
+    slug: Projects.ContractSlug,
+  ) {
     const res = await this.prisma.teamMember.findFirst({
       where: {
         userId,

--- a/backend/src/core/projects/projects.service.ts
+++ b/backend/src/core/projects/projects.service.ts
@@ -6,9 +6,7 @@ import {
   Net,
   User,
   Contract,
-  Environment,
   ApiKey,
-  Org,
 } from '@pc/database/clients/core';
 import { VError } from 'verror';
 import { customAlphabet } from 'nanoid';
@@ -20,6 +18,7 @@ import { ReadonlyService } from './readonly.service';
 import { ApiKeysService } from '../keys/apiKeys.service';
 import { ReadonlyService as UsersReadonlyService } from '../users/readonly.service';
 import { PermissionsService as UsersPermissionsService } from '../users/permissions.service';
+import { Projects } from '@pc/common/types/core';
 
 const nanoid = customAlphabet(
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
@@ -52,9 +51,9 @@ export class ProjectsService {
   async create(
     user: User,
     name: Project['name'],
-    orgSlug?: Org['slug'],
+    orgSlug?: Projects.OrgSlug,
     tutorial?: Project['tutorial'],
-  ): Promise<{ name: Project['name']; slug: Project['slug'] }> {
+  ): Promise<{ name: Project['name']; slug: Projects.ProjectSlug }> {
     if (!orgSlug) {
       try {
         const { slug } = await this.users.getPersonalOrg(user);
@@ -403,12 +402,12 @@ export class ProjectsService {
 
   async addContract(
     callingUser: User,
-    project: Project['slug'],
-    subId: Environment['subId'],
+    project: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
     address: Contract['address'],
   ) {
     let net: Net;
-    let environmentId: Environment['id'];
+    let environmentId: Projects.EnvironmentId;
     try {
       const environment = await this.getActiveEnvironment(project, subId);
       net = environment.net;
@@ -501,8 +500,8 @@ export class ProjectsService {
   }
 
   private async findContract(
-    project: Project['slug'],
-    subId: Environment['subId'],
+    project: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
     address: Contract['address'],
   ) {
     return await this.prisma.contract.findFirst({
@@ -578,8 +577,8 @@ export class ProjectsService {
 
   async getContracts(
     callingUser: User,
-    project: Project['slug'],
-    subId: Environment['subId'],
+    project: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
   ) {
     const environment = await this.getActiveEnvironmentAssert(project, subId);
 
@@ -606,7 +605,7 @@ export class ProjectsService {
     }
   }
 
-  async getContract(callingUser: User, slug: Contract['slug']) {
+  async getContract(callingUser: User, slug: Projects.ContractSlug) {
     await this.permissions.checkUserContractPermission(callingUser.id, slug);
     const { net, address } = await this.readonly.getContract(slug);
     return { slug, net, address };
@@ -640,8 +639,8 @@ export class ProjectsService {
   }
 
   async getActiveEnvironmentAssert(
-    projectSlug: Project['slug'],
-    subId: Environment['subId'],
+    projectSlug: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
   ) {
     // check that project is active
     // quick check, only return minimal info
@@ -677,8 +676,8 @@ export class ProjectsService {
   }
 
   async getActiveEnvironment(
-    projectSlug: Project['slug'],
-    subId: Environment['subId'],
+    projectSlug: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
   ) {
     // check that project is active
     const environment = await this.prisma.environment.findFirst({
@@ -813,8 +812,8 @@ export class ProjectsService {
 
   async getEnvironmentDetails(
     callingUser: User,
-    project: Project['slug'],
-    subId: Environment['subId'],
+    project: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
   ) {
     const environment = await this.getActiveEnvironment(project, subId);
 
@@ -876,7 +875,7 @@ export class ProjectsService {
     }
   }
 
-  async isProjectNameUnique(name: Project['name'], orgSlug: Org['slug']) {
+  async isProjectNameUnique(name: Project['name'], orgSlug: Projects.OrgSlug) {
     try {
       const p = await this.prisma.project.findFirst({
         where: {
@@ -896,7 +895,7 @@ export class ProjectsService {
 
   async getKeysWithKongConsumer(
     callingUser: User,
-    projectSlug: Project['slug'],
+    projectSlug: Projects.ProjectSlug,
   ) {
     const projectWhereUnique = {
       slug: projectSlug,
@@ -921,13 +920,13 @@ export class ProjectsService {
     }
   }
 
-  async getKeys(callingUser: User, projectSlug: Project['slug']) {
+  async getKeys(callingUser: User, projectSlug: Projects.ProjectSlug) {
     return (await this.getKeysWithKongConsumer(callingUser, projectSlug)).map(
       ({ kongConsumerName: _kongConsumerName, ...el }) => el,
     );
   }
 
-  async rotateKey(callingUser: User, keySlug: ApiKey['slug']) {
+  async rotateKey(callingUser: User, keySlug: Projects.ApiKeySlug) {
     let keyRelatedSlugs;
     try {
       keyRelatedSlugs = await this.apiKeys.getKeyDetails(keySlug);
@@ -971,7 +970,7 @@ export class ProjectsService {
 
   async generateKey(
     callingUser: User,
-    projectSlug: Project['slug'],
+    projectSlug: Projects.ProjectSlug,
     description?: ApiKey['description'],
   ) {
     const projectWhereUnique = {
@@ -1006,7 +1005,7 @@ export class ProjectsService {
     }
   }
 
-  async deleteKey(callingUser: User, keySlug: ApiKey['slug']) {
+  async deleteKey(callingUser: User, keySlug: Projects.ApiKeySlug) {
     let keyRelatedSlugs;
     try {
       keyRelatedSlugs = await this.apiKeys.getKeyDetails(keySlug);
@@ -1070,7 +1069,7 @@ export class ProjectsService {
   }
 
   // Deletes api keys associated with an org.
-  async deleteApiKeysByOrg(user: User, orgSlug: Org['slug']) {
+  async deleteApiKeysByOrg(user: User, orgSlug: Projects.OrgSlug) {
     try {
       await this.apiKeys.deleteOrg(user.id, orgSlug);
     } catch (e: any) {

--- a/backend/src/core/projects/readonly.service.ts
+++ b/backend/src/core/projects/readonly.service.ts
@@ -1,15 +1,16 @@
 import { Injectable } from '@nestjs/common';
-import { Contract, Environment, Net, Project } from '@pc/database/clients/core';
+import { Contract, Net } from '@pc/database/clients/core';
 import { PrismaService } from '../prisma.service';
 import { VError } from 'verror';
+import { Projects } from '@pc/common/types/core';
 
 @Injectable()
 export class ReadonlyService {
   constructor(private prisma: PrismaService) {}
 
   async getEnvironmentNet(
-    projectSlug: Project['slug'],
-    subId: Environment['subId'],
+    projectSlug: Projects.ProjectSlug,
+    subId: Projects.EnvironmentId,
   ): Promise<Net> {
     const environment = await this.prisma.environment.findFirst({
       where: {
@@ -28,7 +29,7 @@ export class ReadonlyService {
     return environment.net;
   }
 
-  async getContract(slug: Contract['slug']): Promise<Contract> {
+  async getContract(slug: Projects.ContractSlug): Promise<Contract> {
     const contract = await this.prisma.contract.findUnique({
       where: {
         slug,

--- a/backend/src/core/users/permissions.service.ts
+++ b/backend/src/core/users/permissions.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { User, Org } from '@pc/database/clients/core';
+import { User } from '@pc/database/clients/core';
 import { PrismaService } from '../prisma.service';
 import { VError } from 'verror';
+import { Projects } from '@pc/common/types/core';
 
 @Injectable()
 export class PermissionsService {
   constructor(private prisma: PrismaService) {}
 
-  async checkOrgMembership(userId: User['id'], orgSlug: Org['slug']) {
+  async checkOrgMembership(userId: User['id'], orgSlug: Projects.OrgSlug) {
     const res = await this.prisma.orgMember.findUnique({
       where: {
         orgSlug_userId: {

--- a/backend/src/core/users/readonly.service.ts
+++ b/backend/src/core/users/readonly.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { Org, Team, User } from '@pc/database/clients/core';
 import { VError } from 'verror';
+import { Projects } from '@pc/common/types/core';
 
 @Injectable()
 export class ReadonlyService {
@@ -24,7 +25,7 @@ export class ReadonlyService {
     return org;
   }
 
-  async getDefaultTeam(orgSlug: Org['slug']): Promise<Team> {
+  async getDefaultTeam(orgSlug: Projects.OrgSlug): Promise<Team> {
     const team = await this.prisma.team.findFirst({
       where: {
         name: {

--- a/backend/src/core/users/users.service.ts
+++ b/backend/src/core/users/users.service.ts
@@ -20,6 +20,7 @@ import { ProjectsService } from '../projects/projects.service';
 import firebaseAdmin from 'firebase-admin';
 import { ApiKeysService } from '../keys/apiKeys.service';
 import { getAuth, sendPasswordResetEmail } from 'firebase/auth';
+import { Projects } from '@pc/common/types/core';
 
 const newOrgSlug = customAlphabet(
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
@@ -77,7 +78,7 @@ export class UsersService implements OnModuleInit {
       },
     };
 
-    const orgSlug = newOrgSlug();
+    const orgSlug = newOrgSlug() as Projects.OrgSlug;
     const emsId = newEmsId();
     try {
       await this.apiKeysService.createOrganization(emsId, orgSlug);
@@ -285,7 +286,7 @@ export class UsersService implements OnModuleInit {
 
     const metadata = this.creationMetadata(callingUser);
 
-    const slug = newOrgSlug();
+    const slug = newOrgSlug() as Projects.OrgSlug;
     const emsId = newEmsId();
     try {
       await this.apiKeysService.createOrganization(emsId, slug);
@@ -339,7 +340,7 @@ export class UsersService implements OnModuleInit {
   // TODO members should not be able to invite an admin to the org.
   async inviteToOrg(
     callingUser: User,
-    orgSlug: Org['slug'],
+    orgSlug: Projects.OrgSlug,
     recipient: User['email'],
     role: OrgRole,
   ) {
@@ -434,7 +435,7 @@ export class UsersService implements OnModuleInit {
 
   async removeOrgInvite(
     callingUser: User,
-    orgSlug: Org['slug'],
+    orgSlug: Projects.OrgSlug,
     target: User['email'],
   ) {
     // check that user has permission to remove invites
@@ -610,7 +611,7 @@ export class UsersService implements OnModuleInit {
 
   async removeFromOrg(
     callingUser: User,
-    orgSlug: Org['slug'],
+    orgSlug: Projects.OrgSlug,
     targetUser: User['uid'],
   ) {
     const orgCheck = await this.checkOrgPermission(orgSlug, callingUser.id);
@@ -665,7 +666,7 @@ export class UsersService implements OnModuleInit {
     }
   }
 
-  async listOrgMembers(callingUser: User, orgSlug: Org['slug']) {
+  async listOrgMembers(callingUser: User, orgSlug: Projects.OrgSlug) {
     await this.checkOrgPermission(orgSlug, callingUser.id);
 
     const [members, invites] = await Promise.all([
@@ -756,7 +757,7 @@ export class UsersService implements OnModuleInit {
     }));
   }
 
-  async deleteOrg(callingUser: User, orgSlug: Org['slug']) {
+  async deleteOrg(callingUser: User, orgSlug: Projects.OrgSlug) {
     const orgCheck = await this.checkOrgPermission(orgSlug, callingUser.id);
 
     if (orgCheck.isPersonal) {
@@ -858,7 +859,7 @@ export class UsersService implements OnModuleInit {
 
   async changeOrgRole(
     callingUser: User,
-    orgSlug: Org['slug'],
+    orgSlug: Projects.OrgSlug,
     targetUser: User['uid'],
     role: OrgRole,
   ) {
@@ -945,7 +946,7 @@ export class UsersService implements OnModuleInit {
   }
 
   private async hasOtherAdmin(
-    orgSlug: Org['slug'],
+    orgSlug: Projects.OrgSlug,
     userUid: User['uid'],
   ): Promise<boolean> {
     const otherAdmin = await this.prisma.orgMember.findFirst({
@@ -976,7 +977,7 @@ export class UsersService implements OnModuleInit {
 
   // throws if user does not have permission for org
   private async checkOrgPermission(
-    orgSlug: Org['slug'],
+    orgSlug: Projects.OrgSlug,
     userId: User['id'],
   ): Promise<{ name: string; role: OrgRole; isPersonal: boolean }> {
     const membership = await this.prisma.orgMember.findUnique({

--- a/backend/src/modules/alerts/alerts.service.ts
+++ b/backend/src/modules/alerts/alerts.service.ts
@@ -12,7 +12,7 @@ import {
 
 // TODO should we re-export these types from the core module? So there is no dependency on the core prisma/client
 // yes
-import { User, Project } from '@pc/database/clients/core';
+import { User } from '@pc/database/clients/core';
 import { PermissionsService as ProjectPermissionsService } from '../../core/projects/permissions.service';
 
 import { customAlphabet } from 'nanoid';
@@ -36,6 +36,7 @@ import { DateTime } from 'luxon';
 import { NearRpcService } from '@/src/core/near-rpc/near-rpc.service';
 import { EmailVerificationService } from './email-verification.service';
 import { Alerts } from '@pc/common/types/alerts';
+import { Projects } from '@pc/common/types/core';
 
 const nanoid = customAlphabet(
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
@@ -287,7 +288,7 @@ export class AlertsService {
 
   async updateAlert(
     callingUser: User,
-    id: Alert['id'],
+    id: Alerts.AlertId,
     name?: Alert['name'],
     isPaused?: Alert['isPaused'],
   ) {
@@ -390,7 +391,7 @@ export class AlertsService {
     return alerts.map((a) => this.toAlertDto(a));
   }
 
-  async getAlertDetails(callingUser: User, id: Alert['id']) {
+  async getAlertDetails(callingUser: User, id: Alerts.AlertId) {
     try {
       await this.checkUserAlertPermission(callingUser.id, id);
 
@@ -520,7 +521,7 @@ export class AlertsService {
     });
   }
 
-  async deleteAlert(callingUser: User, id: Alert['id']): Promise<void> {
+  async deleteAlert(callingUser: User, id: Alerts.AlertId): Promise<void> {
     await this.checkUserAlertPermission(callingUser.id, id);
 
     try {
@@ -738,7 +739,7 @@ export class AlertsService {
     }
   }
 
-  async deleteDestination(user: User, id: Destination['id']): Promise<void> {
+  async deleteDestination(user: User, id: Alerts.DestinationId): Promise<void> {
     await this.checkUserDestinationPermission(user.id, id);
 
     try {
@@ -759,7 +760,7 @@ export class AlertsService {
     }
   }
 
-  async listDestinations(user: User, projectSlug: Project['slug']) {
+  async listDestinations(user: User, projectSlug: Projects.ProjectSlug) {
     await this.projectPermissions.checkUserProjectPermission(
       user.id,
       projectSlug,
@@ -824,8 +825,8 @@ export class AlertsService {
 
   async enableDestination(
     callingUser: User,
-    alertId: Alert['id'],
-    destinationId: Destination['id'],
+    alertId: Alerts.AlertId,
+    destinationId: Alerts.DestinationId,
   ) {
     await this.checkUserAlertPermission(callingUser.id, alertId);
     await this.checkAlertDestinationPermission(alertId, destinationId);
@@ -860,8 +861,8 @@ export class AlertsService {
 
   async disableDestination(
     callingUser: User,
-    alertId: Alert['id'],
-    destinationId: Destination['id'],
+    alertId: Alerts.AlertId,
+    destinationId: Alerts.DestinationId,
   ) {
     await this.checkUserAlertPermission(callingUser.id, alertId);
 
@@ -1084,7 +1085,7 @@ export class AlertsService {
     }
   }
 
-  async resendEmailVerification(callingUser: User, id: Destination['id']) {
+  async resendEmailVerification(callingUser: User, id: Alerts.DestinationId) {
     await this.checkUserDestinationPermission(callingUser.id, id);
 
     try {
@@ -1191,7 +1192,7 @@ export class AlertsService {
 
   async rotateWebhookDestinationSecret(
     callingUser: User,
-    id: Destination['id'],
+    id: Alerts.DestinationId,
   ) {
     await this.checkUserDestinationPermission(callingUser.id, id);
 
@@ -1261,7 +1262,7 @@ export class AlertsService {
   // Confirms the user is a member of the alert's project.
   private async checkUserAlertPermission(
     userId: User['id'],
-    id: Alert['id'],
+    id: Alerts.AlertId,
   ): Promise<void> {
     const alert = await this.prisma.alert.findUnique({
       where: {
@@ -1293,7 +1294,7 @@ export class AlertsService {
   // Confirms the user is a member of the webhook's project.
   private async checkUserDestinationPermission(
     userId: User['id'],
-    id: Destination['id'],
+    id: Alerts.DestinationId,
   ): Promise<void> {
     const destination = await this.prisma.destination.findUnique({
       where: {
@@ -1333,8 +1334,8 @@ export class AlertsService {
    * Assumes alert validity has already been checked
    */
   private async checkAlertDestinationPermission(
-    alertId: number,
-    destinationId: number,
+    alertId: Alerts.AlertId,
+    destinationId: Alerts.DestinationId,
   ) {
     const alert = await this.prisma.alert.findUnique({
       where: {
@@ -1413,8 +1414,8 @@ export class AlertsService {
 
   // Checks that the destination belongs to the same project as the alert
   private async checkAlertDestinationCompatibility(
-    projectSlug: Project['slug'],
-    ids: Array<Destination['id']>,
+    projectSlug: Projects.ProjectSlug,
+    ids: Array<Alerts.DestinationId>,
   ) {
     const destinations = await this.prisma.destination.findMany({
       where: {

--- a/backend/src/modules/alerts/triggered-alerts/triggered-alerts.service.ts
+++ b/backend/src/modules/alerts/triggered-alerts/triggered-alerts.service.ts
@@ -11,7 +11,8 @@ import {
   TxMatchingRule,
 } from '../serde/db.types';
 import { VError } from 'verror';
-import { Alerts } from '@pc/common/types/alerts';
+import { Alerts, TriggeredAlerts } from '@pc/common/types/alerts';
+import { Projects } from '@pc/common/types/core';
 
 @Injectable()
 export class TriggeredAlertsService {
@@ -23,12 +24,12 @@ export class TriggeredAlertsService {
 
   async listTriggeredAlertsByProject(
     user: User,
-    projectSlug: Alert['projectSlug'],
-    environmentSubId: Alert['environmentSubId'],
+    projectSlug: Projects.ProjectSlug,
+    environmentSubId: Projects.EnvironmentId,
     skip: number,
     take: number,
     pagingDateTime: Date | undefined,
-    alertId?: number,
+    alertId?: Alerts.AlertId,
   ) {
     await this.projectPermissions.checkUserProjectEnvPermission(
       user.id,
@@ -77,7 +78,7 @@ export class TriggeredAlertsService {
 
   public async getTriggeredAlertDetails(
     user: User,
-    slug: TriggeredAlert['slug'],
+    slug: TriggeredAlerts.TriggeredAlertSlug,
   ) {
     const triggeredAlert = await this.prisma.triggeredAlert.findFirst({
       where: {
@@ -108,9 +109,9 @@ export class TriggeredAlertsService {
 
   private determineWhereClause(
     pagingDateTime: Date | undefined,
-    projectSlug: string,
-    environmentSubId: number,
-    alertId?: number,
+    projectSlug: Projects.ProjectSlug,
+    environmentSubId: Projects.EnvironmentId,
+    alertId?: Alerts.AlertId,
   ): Prisma.TriggeredAlertWhereInput {
     const listWhere: Prisma.TriggeredAlertWhereInput = {
       alert: {

--- a/common/types/alerts/alerts.schema.ts
+++ b/common/types/alerts/alerts.schema.ts
@@ -25,7 +25,7 @@ export type DestinationId = z.infer<typeof destinationId>;
 
 export const alertName = z.string();
 export const databaseAlert = z.strictObject({
-  id: z.number(),
+  id: alertId,
   alertRuleKind,
   name: alertName,
   matchingRule: json,
@@ -42,7 +42,7 @@ export const databaseAlert = z.strictObject({
 
 export const destinationName = z.string();
 export const databaseDestination = z.strictObject({
-  id: z.number(),
+  id: destinationId,
   name: z.string().or(z.null()),
   projectSlug,
   type: destinationType,

--- a/common/types/alerts/triggered-alerts.schema.ts
+++ b/common/types/alerts/triggered-alerts.schema.ts
@@ -17,7 +17,7 @@ export type TriggeredAlertSlug = z.infer<typeof triggeredAlertSlug>;
 
 const triggeredAlert = z.strictObject({
   slug: triggeredAlertSlug,
-  alertId: z.number(),
+  alertId: alertId,
   name: z.string(),
   type: ruleType,
   triggeredInBlockHash: blockHash,

--- a/common/types/core/explorer.schema.ts
+++ b/common/types/core/explorer.schema.ts
@@ -352,4 +352,11 @@ export const query = {
   },
 };
 
-export type { TransactionStatus } from './types';
+export type {
+  TransactionStatus,
+  AccountId,
+  TransactionHash,
+  ReceiptId,
+  YoctoNear,
+  BlockHash,
+} from './types';

--- a/common/types/core/projects.schema.ts
+++ b/common/types/core/projects.schema.ts
@@ -158,3 +158,11 @@ export const mutation = {
     deleteKey: z.unknown(),
   },
 };
+
+export type {
+  EnvironmentId,
+  ProjectSlug,
+  ContractSlug,
+  OrgSlug,
+  ApiKeySlug,
+} from './types';

--- a/common/types/core/users.schema.ts
+++ b/common/types/core/users.schema.ts
@@ -20,7 +20,7 @@ export const query = {
 
   outputs: {
     getAccountDetails: z.strictObject({
-      uid: z.string().optional(),
+      uid: userUid.optional(),
       email: z.string().optional(),
       name: z.string().optional(),
       photoUrl: z.string().optional(),
@@ -125,3 +125,5 @@ export const mutation = {
     resetPassword: z.unknown(),
   },
 };
+
+export type { UserUid } from './types';

--- a/frontend/components/explorer/activity/AccountActivityView.tsx
+++ b/frontend/components/explorer/activity/AccountActivityView.tsx
@@ -204,7 +204,7 @@ const ActivityItemRow: React.FC<RowProps> = ({ item }) => {
 };
 
 type Props = {
-  accountId: string;
+  accountId: Explorer.AccountId;
 };
 
 const AccountActivityView: React.FC<Props> = ({ accountId }) => {

--- a/frontend/components/explorer/transaction/TransactionActions.tsx
+++ b/frontend/components/explorer/transaction/TransactionActions.tsx
@@ -19,7 +19,7 @@ import { Button } from '../../lib/Button';
 import TransactionReceipt from './TransactionReceipt';
 
 type Props = {
-  transactionHash: string | null;
+  transactionHash: Explorer.TransactionHash | null;
 };
 
 type ToogleReceipt = {

--- a/frontend/components/layouts/DashboardLayout/ProjectSelector/ProjectSelector.tsx
+++ b/frontend/components/layouts/DashboardLayout/ProjectSelector/ProjectSelector.tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 
@@ -23,7 +24,7 @@ export function ProjectSelector({ onChange }: Props) {
   const router = useRouter();
 
   const onSelectProject = useCallback(
-    (projectSlug: string, isTutorial: boolean) => {
+    (projectSlug: Projects.ProjectSlug, isTutorial: boolean) => {
       onChange(() => {
         updateProjectContext(projectSlug, null);
         if (router.pathname.startsWith('/tutorials/') && !isTutorial) {

--- a/frontend/hooks/api-keys.ts
+++ b/frontend/hooks/api-keys.ts
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import useSWR from 'swr';
 import type { Fetcher, SWRConfiguration } from 'swr/dist/types';
 
@@ -8,7 +9,7 @@ import { authenticatedPost } from '@/utils/http';
 type ApiKeys = Api.Query.Output<'/projects/getKeys'>;
 
 export function useApiKeys(
-  project: string | undefined,
+  project: Projects.ProjectSlug | undefined,
   swrOptions?: SWRConfiguration<ApiKeys, Api.Query.Error<'/projects/getKeys'>, Fetcher<ApiKeys>>,
 ) {
   const { identity } = useAuth();
@@ -18,10 +19,8 @@ export function useApiKeys(
     error,
     mutate,
   } = useSWR(
-    identity && project ? ['/projects/getKeys', project, identity.uid] : null,
-    (key: '/projects/getKeys', project: string) => {
-      return authenticatedPost(key, { project });
-    },
+    identity && project ? ['/projects/getKeys' as const, project, identity.uid] : null,
+    (key, project) => authenticatedPost(key, { project }),
     swrOptions,
   );
 

--- a/frontend/hooks/auth.ts
+++ b/frontend/hooks/auth.ts
@@ -1,4 +1,4 @@
-import type { User as FirebaseUser } from 'firebase/auth';
+import type { Users } from '@pc/common/types/core';
 import { getAuth, onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect } from 'react';
@@ -6,6 +6,7 @@ import { useSWRConfig } from 'swr';
 import useSWR from 'swr';
 
 import { useAuthStore } from '@/stores/auth';
+import type { AuthStore } from '@/stores/auth/types';
 import analytics from '@/utils/analytics';
 import { authenticatedPost, unauthenticatedPost } from '@/utils/http';
 
@@ -44,8 +45,8 @@ export function useAuthSync() {
 
   useEffect(() => {
     const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(auth, (result: FirebaseUser | null) => {
-      setIdentity(result);
+    const unsubscribe = onAuthStateChanged(auth, (result) => {
+      setIdentity(result as AuthStore['identity']);
       setStatus(result ? 'AUTHENTICATED' : 'UNAUTHENTICATED');
     });
 
@@ -95,7 +96,7 @@ export function useSignOut() {
   return signOut;
 }
 
-export async function deleteAccount(uid: string | undefined) {
+export async function deleteAccount(uid: Users.UserUid | undefined) {
   try {
     await authenticatedPost('/users/deleteAccount');
     analytics.track('Delete account', {

--- a/frontend/hooks/contract-templates.ts
+++ b/frontend/hooks/contract-templates.ts
@@ -1,3 +1,5 @@
+import type { Projects } from '@pc/common/types/core';
+
 export interface ContractTemplate {
   abiFileUrl: string;
   detailSummary: string;
@@ -55,6 +57,6 @@ export function useContractTemplates() {
   return contractTemplates;
 }
 
-export function useContractTemplate(slug?: string | null) {
+export function useContractTemplate(slug?: Projects.ContractSlug | null) {
   return contractTemplates.find((template) => template.slug === slug);
 }

--- a/frontend/hooks/contracts.ts
+++ b/frontend/hooks/contracts.ts
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import type * as RPC from '@pc/common/types/rpc';
 import type { Net } from '@pc/database/clients/core';
 import useSWR from 'swr';
@@ -31,7 +32,7 @@ export async function deleteContract(contract: Contract) {
   }
 }
 
-export function useContracts(project: string, environment: number) {
+export function useContracts(project: Projects.ProjectSlug, environment: number) {
   const { identity } = useAuth();
 
   const {
@@ -51,7 +52,7 @@ export function useContracts(project: string, environment: number) {
   return { contracts, error, mutate };
 }
 
-export function useContract(slug: string | undefined) {
+export function useContract(slug: Projects.ContractSlug | undefined) {
   const { identity } = useAuth();
 
   const {

--- a/frontend/hooks/environments.ts
+++ b/frontend/hooks/environments.ts
@@ -1,9 +1,10 @@
+import type { Projects } from '@pc/common/types/core';
 import useSWR from 'swr';
 
 import { useAuth } from '@/hooks/auth';
 import { authenticatedPost } from '@/utils/http';
 
-export function useEnvironments(project: string | undefined) {
+export function useEnvironments(project: Projects.ProjectSlug | undefined) {
   const { identity } = useAuth();
 
   const {

--- a/frontend/hooks/new-api-keys.ts
+++ b/frontend/hooks/new-api-keys.ts
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import type { KeyedMutator } from 'swr';
 import useSWR from 'swr';
 
@@ -7,7 +8,7 @@ import { authenticatedPost } from '@/utils/http';
 
 type Keys = Api.Query.Output<'/projects/getKeys'>;
 
-export function useApiKeys(project: string) {
+export function useApiKeys(project: Projects.ProjectSlug) {
   const { identity } = useAuth();
 
   const {

--- a/frontend/hooks/project-context.ts
+++ b/frontend/hooks/project-context.ts
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo } from 'react';
 
@@ -16,7 +17,10 @@ const useUpdateProjectContext = () => {
   const updateProjectSettings = useSettingsStore((store) => store.updateProjectSettings);
 
   return useCallback(
-    (selectedProjectSlug: string | undefined, selectedEnvironmentSubId: number | null) => {
+    (
+      selectedProjectSlug: Projects.ProjectSlug | undefined,
+      selectedEnvironmentSubId: Projects.EnvironmentId | null,
+    ) => {
       if (!identityUid) {
         return;
       }
@@ -37,9 +41,11 @@ const useUpdateProjectContext = () => {
 
 // Moving project & environment route params to local storage
 const useMoveProjectContextToLocalStorage = () => {
-  const routeProjectSlug = useRouteParam('project');
+  const routeProjectSlug = useRouteParam('project') as Projects.ProjectSlug | undefined;
   const rawRouteEnvironmentSubId = useRouteParam('environment');
-  const routeEnvironmentSubId = rawRouteEnvironmentSubId ? Number(rawRouteEnvironmentSubId) : Number.NaN;
+  const routeEnvironmentSubId = (
+    rawRouteEnvironmentSubId ? Number(rawRouteEnvironmentSubId) : Number.NaN
+  ) as Projects.EnvironmentId;
   const updateProjectContext = useUpdateProjectContext();
   const router = useRouter();
   const { deactivatePublicMode } = usePublicMode();

--- a/frontend/hooks/projects.ts
+++ b/frontend/hooks/projects.ts
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects, Users } from '@pc/common/types/core';
 import useSWR from 'swr';
 import { mutate } from 'swr';
 
@@ -6,7 +7,7 @@ import { useAuth } from '@/hooks/auth';
 import analytics from '@/utils/analytics';
 import { authenticatedPost } from '@/utils/http';
 
-export async function ejectTutorial(slug: string, name: string) {
+export async function ejectTutorial(slug: Projects.ProjectSlug, name: string) {
   try {
     await authenticatedPost('/projects/ejectTutorial', { slug });
     analytics.track('DC Eject Tutorial Project', {
@@ -28,7 +29,7 @@ export async function ejectTutorial(slug: string, name: string) {
 
 type Projects = Api.Query.Output<'/projects/list'>;
 
-export async function deleteProject(userId: string | undefined, slug: string, name: string) {
+export async function deleteProject(userId: Users.UserUid | undefined, slug: Projects.ProjectSlug, name: string) {
   try {
     await authenticatedPost('/projects/delete', { slug });
     analytics.track('DC Remove Project', {
@@ -52,7 +53,7 @@ export async function deleteProject(userId: string | undefined, slug: string, na
   return false;
 }
 
-export function useProject(projectSlug: string) {
+export function useProject(projectSlug: Projects.ProjectSlug) {
   const { data: project, error } = useSWR(['/projects/getDetails' as const, projectSlug], (key, projectSlug) => {
     return authenticatedPost(key, { slug: projectSlug });
   });
@@ -60,7 +61,7 @@ export function useProject(projectSlug: string) {
   return { project, error };
 }
 
-export const useMaybeProject = (projectSlug: string | undefined) => {
+export const useMaybeProject = (projectSlug: Projects.ProjectSlug | undefined) => {
   const { data: project, error } = useSWR(
     projectSlug ? ['/projects/getDetails' as const, projectSlug] : null,
     (key, projectSlug) => authenticatedPost(key, { slug: projectSlug }),

--- a/frontend/modules/alerts/components/DestinationsSelector.tsx
+++ b/frontend/modules/alerts/components/DestinationsSelector.tsx
@@ -1,3 +1,4 @@
+import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -23,25 +24,25 @@ type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
 export interface OnDestinationSelectionChangeEvent {
   destination: Destination;
   isSelected: boolean;
-  selectedIds: number[];
+  selectedIds: Alerts.DestinationId[];
 }
 
 interface Props {
   debounce?: boolean;
   onChange?: (event: OnDestinationSelectionChangeEvent) => void;
-  selectedIds: number[];
-  setSelectedIds: Dispatch<SetStateAction<number[]>>;
+  selectedIds: Alerts.DestinationId[];
+  setSelectedIds: Dispatch<SetStateAction<Alerts.DestinationId[]>>;
 }
 
 function toggleDestination(
   isSelected: boolean,
   destination: Destination,
-  setSelectedIds: Dispatch<SetStateAction<number[]>>,
+  setSelectedIds: Dispatch<SetStateAction<Alerts.DestinationId[]>>,
   onChange?: (event: OnDestinationSelectionChangeEvent) => void,
 ) {
   if (!destination.isValid) return;
 
-  let ids: number[] = [];
+  let ids: Alerts.DestinationId[] = [];
 
   setSelectedIds((value) => {
     ids = value.filter((id) => id !== destination.id);

--- a/frontend/modules/alerts/components/NewDestinationModal.tsx
+++ b/frontend/modules/alerts/components/NewDestinationModal.tsx
@@ -1,5 +1,6 @@
 import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import { useCallback, useState } from 'react';
 import type { FieldValues } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
@@ -34,7 +35,7 @@ type MappedDestination<K extends DestinationType> = MapDiscriminatedUnion<Destin
 interface Props<K extends DestinationType> {
   onCreate?: (destination: MappedDestination<K>) => void;
   onVerify?: (destination: MappedDestination<K>) => void;
-  projectSlug: string;
+  projectSlug: Projects.ProjectSlug;
   show: boolean;
   setShow: (show: boolean) => void;
 }

--- a/frontend/modules/alerts/components/TriggeredAlerts.tsx
+++ b/frontend/modules/alerts/components/TriggeredAlerts.tsx
@@ -1,3 +1,4 @@
+import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
 import { DateTime } from 'luxon';
 import Link from 'next/link';
@@ -32,8 +33,8 @@ export function TriggeredAlerts() {
   const { environmentSubId, projectSlug } = useSureProjectContext();
   const queryParamAlertFilter = useRouteParam('alertId');
   const { reset, ...pagination } = usePagination();
-  const [filteredAlertId, setFilteredAlertId] = useState(
-    queryParamAlertFilter ? parseInt(queryParamAlertFilter) : undefined,
+  const [filteredAlertId, setFilteredAlertId] = useState<Alerts.AlertId | undefined>(
+    queryParamAlertFilter ? (parseInt(queryParamAlertFilter) as Alerts.AlertId) : undefined,
   );
   const filters = { alertId: filteredAlertId };
   const { triggeredAlertsCount, triggeredAlerts } = useTriggeredAlerts(
@@ -68,7 +69,7 @@ export function TriggeredAlerts() {
 
   function onSelectAlertFilter(alertId: string) {
     reset();
-    setFilteredAlertId(parseInt(alertId));
+    setFilteredAlertId(parseInt(alertId) as Alerts.AlertId);
   }
 
   if (alerts?.length === 0) {

--- a/frontend/modules/alerts/hooks/alerts.ts
+++ b/frontend/modules/alerts/hooks/alerts.ts
@@ -1,4 +1,6 @@
+import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import useSWR from 'swr';
 
 import { useAuth } from '@/hooks/auth';
@@ -39,7 +41,7 @@ export async function deleteAlert(alert: Api.Mutation.Input<'/alerts/deleteAlert
   return false;
 }
 
-export async function disableDestinationForAlert(alertId: number, destinationId: number) {
+export async function disableDestinationForAlert(alertId: Alerts.AlertId, destinationId: Alerts.DestinationId) {
   await authenticatedPost('/alerts/disableDestination', {
     alert: alertId,
     destination: destinationId,
@@ -52,7 +54,7 @@ export async function disableDestinationForAlert(alertId: number, destinationId:
   });
 }
 
-export async function enableDestinationForAlert(alertId: number, destinationId: number) {
+export async function enableDestinationForAlert(alertId: Alerts.AlertId, destinationId: Alerts.DestinationId) {
   await authenticatedPost('/alerts/enableDestination', {
     alert: alertId,
     destination: destinationId,
@@ -79,7 +81,7 @@ export async function updateAlert(data: Api.Mutation.Input<'/alerts/updateAlert'
   return alert;
 }
 
-export function useAlert(alertId: number | undefined) {
+export function useAlert(alertId: Alerts.AlertId | undefined) {
   const { identity } = useAuth();
 
   const {
@@ -96,7 +98,7 @@ export function useAlert(alertId: number | undefined) {
   return { alert, error, mutate };
 }
 
-export function useAlerts(projectSlug: string, environmentSubId: number) {
+export function useAlerts(projectSlug: Projects.ProjectSlug, environmentSubId: Projects.EnvironmentId) {
   const { identity } = useAuth();
   const {
     data: alerts,

--- a/frontend/modules/alerts/hooks/destinations.ts
+++ b/frontend/modules/alerts/hooks/destinations.ts
@@ -1,5 +1,6 @@
 import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import useSWR from 'swr';
 
 import { openToast } from '@/components/lib/Toast';
@@ -58,7 +59,7 @@ export async function updateDestination<K extends Alerts.Destination['type']>(
   return destination as MapDiscriminatedUnion<Alerts.Destination, 'type'>[K];
 }
 
-export function useDestinations(projectSlug: string) {
+export function useDestinations(projectSlug: Projects.ProjectSlug) {
   const { identity } = useAuth();
 
   const {
@@ -73,7 +74,7 @@ export function useDestinations(projectSlug: string) {
   return { destinations, error, mutate, isValidating };
 }
 
-export async function resendEmailVerification(destinationId: number) {
+export async function resendEmailVerification(destinationId: Alerts.DestinationId) {
   try {
     await authenticatedPost('/alerts/resendEmailVerification', { destinationId });
 
@@ -105,7 +106,7 @@ export async function resendEmailVerification(destinationId: number) {
   }
 }
 
-export async function rotateWebhookDestinationSecret(destinationId: number) {
+export async function rotateWebhookDestinationSecret(destinationId: Alerts.DestinationId) {
   const destination = await authenticatedPost('/alerts/rotateWebhookDestinationSecret', {
     destinationId,
   });

--- a/frontend/modules/alerts/hooks/triggered-alerts.ts
+++ b/frontend/modules/alerts/hooks/triggered-alerts.ts
@@ -1,3 +1,5 @@
+import type { Alerts, TriggeredAlerts } from '@pc/common/types/alerts';
+import type { Projects } from '@pc/common/types/core';
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 
@@ -7,14 +9,14 @@ import config from '@/utils/config';
 import { authenticatedPost } from '@/utils/http';
 
 interface TriggeredAlertFilters {
-  alertId?: number;
+  alertId?: Alerts.AlertId;
 }
 
 const refreshInterval = config.defaultLiveDataRefreshIntervalMs;
 
 export function useTriggeredAlerts(
-  projectSlug: string,
-  environmentSubId: number,
+  projectSlug: Projects.ProjectSlug,
+  environmentSubId: Projects.EnvironmentId,
   pagination: Pagination,
   filters: TriggeredAlertFilters,
 ) {
@@ -63,7 +65,7 @@ export function useTriggeredAlerts(
   };
 }
 
-export function useTriggeredAlertDetails(slug: string) {
+export function useTriggeredAlertDetails(slug: TriggeredAlerts.TriggeredAlertSlug) {
   const { identity } = useAuth();
 
   const { data, error } = useSWR(

--- a/frontend/modules/apis/components/ApiKeys.tsx
+++ b/frontend/modules/apis/components/ApiKeys.tsx
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { useRef, useState } from 'react';
 
@@ -37,7 +38,7 @@ export function ApiKeys() {
     key: '',
   });
 
-  async function rotateKey(keySlug: string) {
+  async function rotateKey(keySlug: Projects.ApiKeySlug) {
     showRotationModal && setShowRotationModal(false);
     try {
       mutateKeys((cachedKeys) => {

--- a/frontend/modules/apis/components/CreateApiKeyForm.tsx
+++ b/frontend/modules/apis/components/CreateApiKeyForm.tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/lib/Button';
@@ -17,7 +18,7 @@ interface NewKeyFormData {
 interface Props {
   show: boolean;
   setShow: (show: boolean) => void;
-  projectSlug: string;
+  projectSlug: Projects.ProjectSlug;
 }
 
 const ButtonContainer = styled(Flex, {

--- a/frontend/modules/apis/hooks/api-stats.ts
+++ b/frontend/modules/apis/hooks/api-stats.ts
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import type { RpcStats } from '@pc/common/types/rpcstats';
 import type { DateTime, DateTimeUnit } from 'luxon';
 import { useEffect, useState } from 'react';
@@ -117,8 +118,8 @@ function fillEmptyDateValues(
 type EndpointMetrics = Api.Query.Output<'/rpcstats/endpointMetrics'>;
 
 export function useApiStats(
-  environmentSubId: number,
-  projectSlug: string,
+  environmentSubId: Projects.EnvironmentId,
+  projectSlug: Projects.ProjectSlug,
   timeRangeValue: RpcStats.TimeRangeValue,
   rangeEndTime: DateTime,
 ) {

--- a/frontend/modules/contracts/components/AddContractForm.tsx
+++ b/frontend/modules/contracts/components/AddContractForm.tsx
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Explorer } from '@pc/common/types/core';
 import { useState } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
@@ -29,7 +30,7 @@ interface Props {
 }
 
 interface FormData {
-  contractAddress: string;
+  contractAddress: Explorer.AccountId;
 }
 
 export function AddContractForm(props: Props) {
@@ -85,7 +86,7 @@ export function AddContractForm(props: Props) {
   }
 
   const submitForm: SubmitHandler<FormData> = async ({ contractAddress }) => {
-    const contractAddressValue = contractAddress.trim();
+    const contractAddressValue = contractAddress.trim() as Explorer.AccountId;
     try {
       const contract = await authenticatedPost('/projects/addContract', {
         project: projectSlug,
@@ -182,7 +183,7 @@ export function AddContractForm(props: Props) {
                       message: 'Invalid address format.',
                     },
                   })}
-                  onChange={(e) => setValue('contractAddress', e.target.value.trim())}
+                  onChange={(e) => setValue('contractAddress', e.target.value.trim() as Explorer.AccountId)}
                 />
                 <Form.Feedback>{formState.errors.contractAddress?.message}</Form.Feedback>
               </Form.Group>

--- a/frontend/modules/contracts/components/ContractWrapper.tsx
+++ b/frontend/modules/contracts/components/ContractWrapper.tsx
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import type { ReactElement } from 'react';
 
 import { GetPublicModeWrapper } from '@/components/lib/PublicModeWrapper';
@@ -15,7 +16,7 @@ type ChildrenProps = {
 };
 
 type Props = {
-  slug: string;
+  slug: Projects.ContractSlug;
   children: (props: ChildrenProps) => ReactElement | null;
 };
 

--- a/frontend/modules/contracts/components/UploadContractAbi.tsx
+++ b/frontend/modules/contracts/components/UploadContractAbi.tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import type { ChangeEvent, DragEvent } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -18,7 +19,7 @@ import { StableId } from '@/utils/stable-ids';
 const MAX_CODE_HEIGHT = '18rem';
 
 type Props = {
-  contractSlug: string;
+  contractSlug: Projects.ContractSlug;
   setAbiUploaded: (arg0: boolean) => void;
 };
 

--- a/frontend/modules/contracts/components/contract-transaction/TxFormWalletLogin.tsx
+++ b/frontend/modules/contracts/components/contract-transaction/TxFormWalletLogin.tsx
@@ -1,3 +1,5 @@
+import type { Projects } from '@pc/common/types/core';
+
 import { Button } from '@/components/lib/Button';
 import { CopyButton } from '@/components/lib/CopyButton';
 import { FeatherIcon } from '@/components/lib/FeatherIcon';
@@ -19,7 +21,7 @@ const ButtonWallet = styled(Button, {
 });
 
 const TxFormWalletLogin = ({ onBeforeLogIn }: TxFormWalletLoginProps) => {
-  const contractSlug = useRouteParam('slug', '/contracts', true) || undefined;
+  const contractSlug = (useRouteParam('slug', '/contracts', true) || undefined) as Projects.ContractSlug | undefined;
   const { contract: { address: contractId } = {} } = useContract(contractSlug);
   const { accountId, signOut, modal } = useWalletSelector(contractId);
 

--- a/frontend/modules/contracts/components/contract-transaction/TxResultHash.tsx
+++ b/frontend/modules/contracts/components/contract-transaction/TxResultHash.tsx
@@ -1,3 +1,5 @@
+import type { Explorer } from '@pc/common/types/core';
+
 import TransactionActions from '@/components/explorer/transaction/TransactionActions';
 import { NetContext } from '@/components/explorer/utils/NetContext';
 import { Box } from '@/components/lib/Box';
@@ -13,7 +15,7 @@ const ResultTitle = styled(H5, {
 });
 
 const TxResultHash = ({ result, net }: TxResultHashProps) => {
-  const hash = result?.hash as string;
+  const hash = result?.hash as Explorer.TransactionHash | null;
 
   return (
     <Flex stack>

--- a/frontend/modules/contracts/hooks/abi.ts
+++ b/frontend/modules/contracts/hooks/abi.ts
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import type { Net } from '@pc/database/clients/core';
 import type { AbiRoot, AnyContract } from 'near-abi-client-js';
 import { Contract as NearContract } from 'near-abi-client-js';
@@ -53,7 +54,7 @@ export const useEmbeddedAbi = (net: Net | undefined, address: string | undefined
   return { embeddedAbi, error, mutate };
 };
 
-export const useContractAbi = (contract: string | undefined) => {
+export const useContractAbi = (contract: Projects.ContractSlug | undefined) => {
   const { identity } = useAuth();
   const {
     data: contractAbi,
@@ -69,7 +70,7 @@ export const useContractAbi = (contract: string | undefined) => {
   return { contractAbi: contractAbi?.abi, error, mutate };
 };
 
-export const uploadContractAbi = async (contractSlug: string, abi: AbiRoot) => {
+export const uploadContractAbi = async (contractSlug: Projects.ContractSlug, abi: AbiRoot) => {
   try {
     await authenticatedPost('/abi/addContractAbi', {
       contract: contractSlug,

--- a/frontend/modules/contracts/hooks/recent-transactions.ts
+++ b/frontend/modules/contracts/hooks/recent-transactions.ts
@@ -1,3 +1,4 @@
+import type { Explorer } from '@pc/common/types/core';
 import type * as RPC from '@pc/common/types/rpc';
 import type { Net } from '@pc/database/clients/core';
 import JSBI from 'jsbi';
@@ -15,7 +16,7 @@ export function useRecentTransactions(contract: string | undefined, net: Net | u
     contract && net ? ['/explorer/getTransactions' as const, contract, net] : null,
     (key, contracts, net) => {
       return unauthenticatedPost(key, {
-        contracts: contracts.split(','),
+        contracts: contracts.split(',') as Explorer.AccountId[],
         net,
       });
     },

--- a/frontend/modules/core/components/modals/DeleteProjectModal.tsx
+++ b/frontend/modules/core/components/modals/DeleteProjectModal.tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import { useState } from 'react';
 
 import { Text } from '@/components/lib/Text';
@@ -6,7 +7,7 @@ import { useAuth } from '@/hooks/auth';
 import { deleteProject } from '@/hooks/projects';
 
 interface Props {
-  slug: string;
+  slug: Projects.ProjectSlug;
   name: string;
   show: boolean;
   setShow: (show: boolean) => void;

--- a/frontend/modules/core/components/modals/EjectProjectModal.tsx
+++ b/frontend/modules/core/components/modals/EjectProjectModal.tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import { useState } from 'react';
 
 import { FeatherIcon } from '@/components/lib/FeatherIcon';
@@ -7,7 +8,7 @@ import { ConfirmModal } from '@/components/modals/ConfirmModal';
 import { ejectTutorial } from '@/hooks/projects';
 
 interface Props {
-  slug: string;
+  slug: Projects.ProjectSlug;
   name: string;
   show: boolean;
   setShow: (show: boolean) => void;

--- a/frontend/pages/alerts/edit-alert/[alertId].tsx
+++ b/frontend/pages/alerts/edit-alert/[alertId].tsx
@@ -1,3 +1,4 @@
+import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -63,16 +64,16 @@ async function update(alert: Api.Mutation.Input<'/alerts/updateAlert'>, data: { 
 
 const EditAlert: NextPageWithLayout = () => {
   const router = useRouter();
-  const alertId = parseInt(router.query.alertId as string);
+  const alertId = parseInt(router.query.alertId as string) as Alerts.AlertId;
   const nameForm = useForm<NameFormData>();
   const { alert, mutate } = useAlert(alertId);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [alertIsActive, setAlertIsActive] = useState(true);
   const [isEditingName, setIsEditingName] = useState(false);
-  const [selectedDestinationIds, setSelectedDestinationIds] = useState<number[]>([]);
+  const [selectedDestinationIds, setSelectedDestinationIds] = useState<Alerts.DestinationId[]>([]);
 
   useEffect(() => {
-    const destinationIds: number[] = [];
+    const destinationIds: Alerts.DestinationId[] = [];
 
     if (alert) {
       setAlertIsActive(!alert.isPaused);

--- a/frontend/pages/alerts/new-alert.tsx
+++ b/frontend/pages/alerts/new-alert.tsx
@@ -1,5 +1,6 @@
 import type { Alerts } from '@pc/common/types/alerts';
 import type { Api } from '@pc/common/types/api';
+import type { Explorer, Projects } from '@pc/common/types/core';
 import { useCombobox } from 'downshift';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -40,7 +41,7 @@ import type { NextPageWithLayout } from '@/utils/types';
 import { validateMaxNearDecimalLength, validateMaxNearU128 } from '@/utils/validations';
 
 interface FormData {
-  contract: string;
+  contract: Explorer.AccountId;
   type: Alerts.RuleType;
   acctBalRule?: {
     comparator: Alerts.Comparator;
@@ -71,7 +72,7 @@ const NewAlert: NextPageWithLayout = () => {
   const { projectSlug, environmentSubId } = useSureProjectContext();
   const { mutate } = useAlerts(projectSlug, environmentSubId);
   const [createError, setCreateError] = useState('');
-  const [selectedDestinationIds, setSelectedDestinationIds] = useState<number[]>([]);
+  const [selectedDestinationIds, setSelectedDestinationIds] = useState<Alerts.DestinationId[]>([]);
   const { contracts } = useContracts(projectSlug, environmentSubId);
   const [contractComboboxItems, setContractComboboxItems] = useState<Contract[]>([]);
 
@@ -569,9 +570,9 @@ NewAlert.getLayout = wrapDashboardLayoutWithOptions({
 
 function returnNewAlertBody(
   data: FormData,
-  destinations: number[],
-  projectSlug: string,
-  environmentSubId: number,
+  destinations: Alerts.DestinationId[],
+  projectSlug: Projects.ProjectSlug,
+  environmentSubId: Projects.EnvironmentId,
 ): Api.Mutation.Input<'/alerts/createAlert'> {
   const base = {
     destinations,

--- a/frontend/pages/alerts/triggered-alert/[triggeredAlertId].tsx
+++ b/frontend/pages/alerts/triggered-alert/[triggeredAlertId].tsx
@@ -67,7 +67,7 @@ function LabelAndValue(props: {
 
 const ViewTriggeredAlert: NextPageWithLayout = () => {
   const router = useRouter();
-  const triggeredAlertId = router.query.triggeredAlertId as string;
+  const triggeredAlertId = router.query.triggeredAlertId as TriggeredAlerts.TriggeredAlertSlug;
   const { triggeredAlert, error } = useTriggeredAlertDetails(triggeredAlertId);
   const { alert } = useAlert(triggeredAlert?.alertId);
   const { environmentSubId, updateContext: updateProjectContext } = useSureProjectContext();

--- a/frontend/pages/contracts/[slug].tsx
+++ b/frontend/pages/contracts/[slug].tsx
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects } from '@pc/common/types/core';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
@@ -67,7 +68,7 @@ const ContractAbiTab = ({ contract }: { contract: Contract | undefined }) => {
 const ViewContract: NextPageWithLayout = () => {
   const { publicModeIsActive } = usePublicMode();
   const router = useRouter();
-  const contractSlug = useRouteParam('slug', '/contracts', true) || '';
+  const contractSlug = (useRouteParam('slug', '/contracts', true) || '') as Projects.ContractSlug;
   const activeTab = useRouteParam('tab', `/contracts/${contractSlug}?tab=details`, true);
   const { identity } = useAuth();
   const { projectSlug, environmentSubId } = useMaybeProjectContext();

--- a/frontend/pages/new-project.tsx
+++ b/frontend/pages/new-project.tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import type { ChangeEvent } from 'react';
@@ -31,7 +32,7 @@ const PERSONAL_ORGANIZATION_NAME = 'Personal organization';
 
 interface NewProjectFormData {
   projectName: string;
-  projectOrg: string;
+  projectOrg: Projects.OrgSlug;
 }
 
 const NewProject: NextPageWithLayout = () => {
@@ -103,7 +104,7 @@ const NewProject: NextPageWithLayout = () => {
     }
   };
 
-  const setProjectOrg = useCallback((value: string) => setValue('projectOrg', value), [setValue]);
+  const setProjectOrg = useCallback((value: string) => setValue('projectOrg', value as Projects.OrgSlug), [setValue]);
 
   const selectedOrganizationSlug = watch('projectOrg');
   const selectedOrganization = organizations.find((organization) => organization.slug === selectedOrganizationSlug);

--- a/frontend/pages/organizations/[slug].tsx
+++ b/frontend/pages/organizations/[slug].tsx
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Projects, Users } from '@pc/common/types/core';
 import type { OrgRole } from '@pc/database/clients/core';
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -69,7 +70,7 @@ const Trigger = styled('div', {
 
 type RemovingUserData =
   | {
-      uid: string;
+      uid: Users.UserUid;
       email: string;
     }
   | {
@@ -81,7 +82,7 @@ const RemoveUserDialog = ({
   userData,
   setUserData,
 }: {
-  orgSlug: string;
+  orgSlug: Projects.OrgSlug;
   userData: RemovingUserData;
   setUserData: (data?: RemovingUserData) => void;
 }) => {
@@ -271,7 +272,7 @@ const InviteUserDialog = ({
   modalOpen,
   switchModal,
 }: {
-  orgSlug: string;
+  orgSlug: Projects.OrgSlug;
   modalOpen: boolean;
   switchModal: () => void;
 }) => {
@@ -347,7 +348,7 @@ const OrganizationsDropdown = ({ selectedOrganization }: { selectedOrganization?
 
 const OrganizationView: NextPageWithLayout = () => {
   const router = useRouter();
-  const orgSlug = useRouteParam('slug', '/organizations', true) || '';
+  const orgSlug = (useRouteParam('slug', '/organizations', true) || '') as Projects.OrgSlug;
   const { members, error, mutate: refetchOrganization } = useOrgMembers(orgSlug);
   const { identity } = useAuth();
   const self = members?.find((member) => member.user.uid === identity?.uid);
@@ -370,7 +371,7 @@ const OrganizationView: NextPageWithLayout = () => {
     if (!selectedOrganization) {
       return;
     }
-    deleteMutation.mutate({ org: selectedOrganization.name });
+    deleteMutation.mutate({ org: selectedOrganization.slug });
   }, [deleteMutation, selectedOrganization]);
 
   return (

--- a/frontend/pages/pick-project-template/[templateSlug].tsx
+++ b/frontend/pages/pick-project-template/[templateSlug].tsx
@@ -1,3 +1,4 @@
+import type { Projects } from '@pc/common/types/core';
 import { DateTime } from 'luxon';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -22,7 +23,7 @@ import type { NextPageWithLayout } from '@/utils/types';
 
 const ViewProjectTemplate: NextPageWithLayout = () => {
   const router = useRouter();
-  const slug = useRouteParam('templateSlug');
+  const slug = useRouteParam('templateSlug') as Projects.ContractSlug;
   const template = useContractTemplate(slug);
   const { authStatus } = useAuth();
   const [isDeploying, setIsDeploying] = useState(false);

--- a/frontend/pages/public/[redirectPageName].tsx
+++ b/frontend/pages/public/[redirectPageName].tsx
@@ -1,4 +1,5 @@
 import type { Api } from '@pc/common/types/api';
+import type { Explorer, Projects } from '@pc/common/types/core';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
@@ -29,7 +30,7 @@ const Public: NextPageWithLayout = () => {
   const addressesParam = router.query.addresses as string;
   const sharedParam = router.query.shared as string;
   const netParam = router.query.net as NetOption;
-  const addresses = addressesParam ? addressesParam.split(',') : [];
+  const addresses = (addressesParam ? addressesParam.split(',') : []) as Explorer.AccountId[];
   const addressesAreValid = addresses.length > 0;
   const netIsValid = netOptions.includes(netParam);
   const routeNameIsValid = ['analytics', 'contracts'].includes(redirectPageNameParam);
@@ -52,7 +53,7 @@ const Public: NextPageWithLayout = () => {
     const contracts: Contract[] = addresses.map((address) => {
       return {
         address,
-        slug: address,
+        slug: address as unknown as Projects.ContractSlug,
         net: netParam,
       };
     });

--- a/frontend/pages/ui.tsx
+++ b/frontend/pages/ui.tsx
@@ -1,3 +1,4 @@
+import type { Explorer } from '@pc/common/types/core';
 import type { Net } from '@pc/database/clients/core';
 import { useCombobox } from 'downshift';
 import Link from 'next/link';
@@ -239,8 +240,8 @@ const WithNetDropdown: FC<{ children: ReactNode }> = ({ children }) => {
 };
 
 const AccountActivitySection = () => {
-  const form = useForm<{ contractId: string }>();
-  const [address, setAddress] = useState('');
+  const form = useForm<{ contractId: Explorer.AccountId }>();
+  const [address, setAddress] = useState<Explorer.AccountId>('' as Explorer.AccountId);
 
   return (
     <>
@@ -261,8 +262,8 @@ const AccountActivitySection = () => {
 };
 
 const TransactionSection = () => {
-  const form = useForm<{ transactionHash: string }>();
-  const [hash, setHash] = useState('');
+  const form = useForm<{ transactionHash: Explorer.TransactionHash }>();
+  const [hash, setHash] = useState<Explorer.TransactionHash>('' as Explorer.TransactionHash);
   const net = useNet();
 
   return (

--- a/frontend/stores/auth/types.ts
+++ b/frontend/stores/auth/types.ts
@@ -1,10 +1,13 @@
+import type { Users } from '@pc/common/types/core';
 import type { User as FirebaseUser } from 'firebase/auth';
 
 type AuthStatus = 'LOADING' | 'AUTHENTICATED' | 'UNAUTHENTICATED';
 
+type FlavoredUser = Omit<FirebaseUser, 'uid'> & { uid: Users.UserUid };
+
 export interface AuthStore {
-  identity: FirebaseUser | null;
+  identity: FlavoredUser | null;
   status: AuthStatus;
-  setIdentity: (identity: FirebaseUser | null) => void;
+  setIdentity: (identity: FlavoredUser | null) => void;
   setStatus: (status: AuthStatus) => void;
 }

--- a/frontend/stores/settings/settings.ts
+++ b/frontend/stores/settings/settings.ts
@@ -1,9 +1,10 @@
+import type { Users } from '@pc/common/types/core';
 import { merge } from 'lodash-es';
 import create from 'zustand';
 
 import type { SettingsStore } from './types';
 
-function getUser(userId: string, state: SettingsStore) {
+function getUser(userId: Users.UserUid, state: SettingsStore) {
   state.users[userId] ||= {
     projects: {},
   };

--- a/frontend/stores/settings/types.ts
+++ b/frontend/stores/settings/types.ts
@@ -1,20 +1,26 @@
+import type { Projects, Users } from '@pc/common/types/core';
+
 import type { PersistedStore } from '@/utils/types';
 
 export interface ProjectSettings {
   nftContract?: string;
-  selectedEnvironmentSubId?: number;
+  selectedEnvironmentSubId?: Projects.EnvironmentId;
 }
 
 export interface UserSettings {
-  projects: Record<string, ProjectSettings | undefined>;
-  selectedProjectSlug?: string;
+  projects: Record<Projects.ProjectSlug, ProjectSettings | undefined>;
+  selectedProjectSlug?: Projects.ProjectSlug;
 }
 
 export interface SettingsStore extends PersistedStore {
   currentUser: UserSettings | undefined;
   hasInitialized: boolean;
-  users: Record<string, UserSettings | undefined>;
-  initializeCurrentUserSettings: (userId: string) => void;
-  updateSettings: (userId: string, settings: Partial<UserSettings>) => void;
-  updateProjectSettings: (userId: string, projectSlug: string, settings: Partial<ProjectSettings>) => void;
+  users: Record<Users.UserUid, UserSettings | undefined>;
+  initializeCurrentUserSettings: (userId: Users.UserUid) => void;
+  updateSettings: (userId: Users.UserUid, settings: Partial<UserSettings>) => void;
+  updateProjectSettings: (
+    userId: Users.UserUid,
+    projectSlug: Projects.ProjectSlug,
+    settings: Partial<ProjectSettings>,
+  ) => void;
 }

--- a/frontend/utils/deploy-contract-template.ts
+++ b/frontend/utils/deploy-contract-template.ts
@@ -1,3 +1,4 @@
+import type { Explorer } from '@pc/common/types/core';
 import { connect, KeyPair, keyStores, transactions } from 'near-api-js';
 
 import config from '@/utils/config';
@@ -18,7 +19,7 @@ export async function deployContractTemplate(template: ContractTemplate) {
   };
   const near = await connect(nearConfig);
   const randomNumber = Math.floor(Math.random() * (99999999999999 - 10000000000000) + 10000000000000);
-  const accountId = `dev-${Date.now()}-${randomNumber}`;
+  const accountId = `dev-${Date.now()}-${randomNumber}` as Explorer.AccountId;
   const keyPair = KeyPair.fromRandom('ed25519');
 
   try {

--- a/frontend/utils/helpers.ts
+++ b/frontend/utils/helpers.ts
@@ -1,10 +1,11 @@
+import type { Projects } from '@pc/common/types/core';
 import type { Net } from '@pc/common/types/core/types';
 
 export function assertUnreachable(x: never): never {
   throw new Error(`Unreachable Case: ${x}`);
 }
 
-export function returnContractAddressRegex(environmentSubId: number) {
+export function returnContractAddressRegex(environmentSubId: Projects.EnvironmentId) {
   // https://docs.near.org/docs/concepts/account#account-id-rules
 
   const prefix = '^(([a-z\\d]+[\\-_])*[a-z\\d]+\\.)*([a-z\\d]+[\\-_])*[a-z\\d]+';
@@ -33,7 +34,7 @@ export function sleep(ms: number) {
 
 export const nonNullishGuard = <T>(arg: T): arg is Exclude<T, null | undefined> => arg !== null && arg !== undefined;
 
-export const mapEnvironmentSubIdToNet = (environmentSubId: number): Net => {
+export const mapEnvironmentSubIdToNet = (environmentSubId: Projects.EnvironmentId): Net => {
   switch (environmentSubId) {
     case 2:
       return 'MAINNET';


### PR DESCRIPTION
In this PR we enforce the flavoring.
To migrate to branding instead of flavoring we need to figure out how to substitute generated DB types strings to proper flavors.