### PR TITLE
Remove prisma fields from dbml

### DIFF
--- a/.github/workflows/dbdocs-dev.yml
+++ b/.github/workflows/dbdocs-dev.yml
@@ -24,11 +24,13 @@ jobs:
       - name: Check dbdocs
         run: dbdocs
 
+        # 0.10.0-dev.1 version of the dbml generator contains the includeRelationFields config option.
+        # TODO pin to a stable version once released
       - name: Install DB Generator for Prisma
-        run: npm install prisma-dbml-generator
+        run: npm install prisma-dbml-generator@0.10.0-dev.1
 
       - name: add generator to Prisma's schema
-        run: printf '\ngenerator dbml {\n  provider = "prisma-dbml-generator"\n}' >> ./database/schemas/core/schema.prisma
+        run: printf '\ngenerator dbml {\n  provider = "prisma-dbml-generator"\n  includeRelationFields = "false"\n}' >> ./database/schemas/core/schema.prisma
 
       - name: Generate DB Docs schema file
         run: npx prisma generate --schema ./database/schemas/core/schema.prisma

--- a/.github/workflows/dbdocs.yml
+++ b/.github/workflows/dbdocs.yml
@@ -25,10 +25,10 @@ jobs:
         run: dbdocs
 
       - name: Install DB Generator for Prisma
-        run: npm install prisma-dbml-generator
+        run: npm install prisma-dbml-generator@0.10.0-dev.1
 
       - name: add generator to Prisma's schema
-        run: printf '\ngenerator dbml {\n  provider = "prisma-dbml-generator"\n}' >> ./database/schemas/core/schema.prisma
+        run: printf '\ngenerator dbml {\n  provider = "prisma-dbml-generator"\n  includeRelationFields = "false"\n}' >> ./database/schemas/core/schema.prisma
 
       - name: Generate DB Docs schema file
         run: npx prisma generate --schema ./database/schemas/core/schema.prisma


### PR DESCRIPTION
Our current DBML that we share internally contains a bunch of Prisma-related fields that don't actually exist in our DB. To reduce confusion, we wanted to remove/hide these fields from our DBML.

Prisma-dbml-generator now supports this feature: https://github.com/notiz-dev/prisma-dbml-generator/releases/tag/v0.10.0-dev.1

closes: https://github.com/near/developer-console-api/issues/101