### PR TITLE
Refactor: resetError in modals

### DIFF
--- a/frontend/components/modals/ConfirmModal.tsx
+++ b/frontend/components/modals/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useCallback } from 'react';
 
 import * as Dialog from '@/components/lib/Dialog';
 import { StableId } from '@/utils/stable-ids';
@@ -17,27 +18,24 @@ interface Props {
   isProcessing?: boolean;
   disabled?: boolean;
   onConfirm?: () => void;
-  setErrorText?: (error: string) => void;
+  resetError?: () => void;
   setShow: (show: boolean) => void;
   size?: 's' | 'm';
   show: boolean;
   title: string;
 }
 
-export function ConfirmModal(props: Props) {
+export function ConfirmModal({ setShow, ...props }: Props) {
   const size = props.size || 's';
+  const hideDialog = useCallback(() => setShow(false), [setShow]);
 
   return (
-    <Dialog.Root open={props.show} onOpenChange={props.setShow}>
+    <Dialog.Root open={props.show} onOpenChange={setShow}>
       <Dialog.Content title={props.title} size={size}>
         <Flex stack gap="l">
           {props.children}
 
-          <Message
-            content={props.errorText}
-            type="error"
-            dismiss={props.setErrorText ? () => props.setErrorText!('') : undefined}
-          />
+          <Message content={props.errorText} type="error" dismiss={props.resetError} />
 
           <Flex justify="spaceBetween" align="center">
             <Button
@@ -50,13 +48,7 @@ export function ConfirmModal(props: Props) {
               {props.confirmText || 'Confirm'}
             </Button>
 
-            <TextButton
-              stableId={StableId.CONFIRM_MODAL_CANCEL_BUTTON}
-              color="neutral"
-              onClick={() => {
-                props.setShow(false);
-              }}
-            >
+            <TextButton stableId={StableId.CONFIRM_MODAL_CANCEL_BUTTON} color="neutral" onClick={hideDialog}>
               {props.cancelText || 'Cancel'}
             </TextButton>
           </Flex>

--- a/frontend/components/modals/ErrorModal.tsx
+++ b/frontend/components/modals/ErrorModal.tsx
@@ -10,10 +10,10 @@ import { Text } from '../lib/Text';
 
 interface Props {
   error?: string | null;
-  setError: (error: string) => void;
+  resetError: () => void;
 }
 
-export const ErrorModal = ({ error, setError }: Props) => {
+export const ErrorModal = ({ error, resetError }: Props) => {
   const [errorCopy, setErrorCopy] = useState('');
 
   useEffect(() => {
@@ -21,17 +21,13 @@ export const ErrorModal = ({ error, setError }: Props) => {
     // This copy is needed so the modal doesn't jump while closing due to the error disappearing
   }, [error, errorCopy]);
 
-  function close() {
-    setError('');
-  }
-
   return (
     <Dialog.Root open={!!error}>
       <Dialog.Content size="s">
         <Flex stack gap="l" align="center">
           <FeatherIcon icon="alert-circle" color="danger" size="l" />
           <Text size="h5">{errorCopy}</Text>
-          <Button stableId={StableId.ERROR_MODAL_DISMISS_BUTTON} color="neutral" onClick={close}>
+          <Button stableId={StableId.ERROR_MODAL_DISMISS_BUTTON} color="neutral" onClick={resetError}>
             Dismiss
           </Button>
         </Flex>

--- a/frontend/modules/alerts/components/DeleteAlertModal.tsx
+++ b/frontend/modules/alerts/components/DeleteAlertModal.tsx
@@ -1,5 +1,5 @@
 import type { Api } from '@pc/common/types/api';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Text } from '@/components/lib/Text';
 import { ConfirmModal } from '@/components/modals/ConfirmModal';
@@ -32,6 +32,7 @@ export function DeleteAlertModal({ alert, show, setShow, onDelete }: Props) {
       setIsDeleting(false);
     }
   }
+  const resetError = useCallback(() => setErrorText(''), [setErrorText]);
 
   return (
     <ConfirmModal
@@ -40,7 +41,7 @@ export function DeleteAlertModal({ alert, show, setShow, onDelete }: Props) {
       errorText={errorText}
       isProcessing={isDeleting}
       onConfirm={onConfirm}
-      setErrorText={setErrorText}
+      resetError={resetError}
       setShow={setShow}
       show={show}
       title={`Delete Alert`}

--- a/frontend/modules/alerts/components/DeleteDestinationModal.tsx
+++ b/frontend/modules/alerts/components/DeleteDestinationModal.tsx
@@ -1,5 +1,5 @@
 import type { Api } from '@pc/common/types/api';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Card } from '@/components/lib/Card';
 import { FeatherIcon } from '@/components/lib/FeatherIcon';
@@ -53,6 +53,7 @@ export function DeleteDestinationModal({ destination, show, setShow, onDelete }:
       setIsDeleting(false);
     }
   }
+  const resetError = useCallback(() => setErrorText(''), [setErrorText]);
 
   return (
     <ConfirmModal
@@ -61,7 +62,7 @@ export function DeleteDestinationModal({ destination, show, setShow, onDelete }:
       errorText={errorText}
       isProcessing={isDeleting}
       onConfirm={onConfirm}
-      setErrorText={setErrorText}
+      resetError={resetError}
       setShow={setShow}
       show={show}
       title={`Delete Destination`}

--- a/frontend/modules/core/components/AuthForm/AuthForm.tsx
+++ b/frontend/modules/core/components/AuthForm/AuthForm.tsx
@@ -9,7 +9,7 @@ import {
 import { GithubAuthProvider, GoogleAuthProvider } from 'firebase/auth';
 import { useRouter } from 'next/router';
 // import { useTranslation } from 'next-i18next';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/lib/Button';
 import { Flex } from '@/components/lib/Flex';
@@ -147,6 +147,7 @@ export function AuthForm({ onSignIn }: Props) {
       }
     }
   }
+  const resetError = useCallback(() => setAuthError(''), [setAuthError]);
 
   return (
     <Flex gap="l" stack>
@@ -165,7 +166,7 @@ export function AuthForm({ onSignIn }: Props) {
         ))}
       </Flex>
 
-      <ErrorModal error={authError} setError={setAuthError} />
+      <ErrorModal error={authError} resetError={resetError} />
     </Flex>
   );
 }

--- a/frontend/modules/core/components/modals/DeleteAccountModal.tsx
+++ b/frontend/modules/core/components/modals/DeleteAccountModal.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { List, ListItem } from '@/components/lib/List';
 import { Message } from '@/components/lib/Message';
@@ -36,6 +36,7 @@ export default function DeleteAccountModal({
       setIsDeleting(false);
     }
   }
+  const resetError = useCallback(() => setErrorText(''), [setErrorText]);
 
   const isOnlyAdmin = organizations && organizations.length > 0;
 
@@ -46,7 +47,7 @@ export default function DeleteAccountModal({
       errorText={errorText}
       isProcessing={isDeleting}
       onConfirm={onConfirm}
-      setErrorText={setErrorText}
+      resetError={resetError}
       setShow={setShow}
       show={show}
       disabled={isOnlyAdmin}

--- a/frontend/modules/core/components/modals/DeleteProjectModal.tsx
+++ b/frontend/modules/core/components/modals/DeleteProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Text } from '@/components/lib/Text';
 import { ConfirmModal } from '@/components/modals/ConfirmModal';
@@ -32,6 +32,7 @@ export default function DeleteProjectModal({ slug, name, show, setShow, onDelete
       setIsDeleting(false);
     }
   }
+  const resetError = useCallback(() => setErrorText(''), [setErrorText]);
 
   return (
     <ConfirmModal
@@ -40,7 +41,7 @@ export default function DeleteProjectModal({ slug, name, show, setShow, onDelete
       errorText={errorText}
       isProcessing={isDeleting}
       onConfirm={onConfirm}
-      setErrorText={setErrorText}
+      resetError={resetError}
       setShow={setShow}
       show={show}
       title={`Remove ${name}`}

--- a/frontend/modules/core/components/modals/EjectProjectModal.tsx
+++ b/frontend/modules/core/components/modals/EjectProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { FeatherIcon } from '@/components/lib/FeatherIcon';
 import { Flex } from '@/components/lib/Flex';
@@ -32,6 +32,7 @@ export const EjectProjectModal = ({ slug, name, show, setShow, onEject }: Props)
       setIsEjecting(false);
     }
   }
+  const resetError = useCallback(() => setErrorText(''), [setErrorText]);
 
   return (
     <ConfirmModal
@@ -39,7 +40,7 @@ export const EjectProjectModal = ({ slug, name, show, setShow, onEject }: Props)
       errorText={errorText}
       isProcessing={isEjecting}
       onConfirm={onConfirm}
-      setErrorText={setErrorText}
+      resetError={resetError}
       setShow={setShow}
       show={show}
       title={`Complete ${name}`}

--- a/frontend/pages/alerts/new-alert.tsx
+++ b/frontend/pages/alerts/new-alert.tsx
@@ -3,7 +3,7 @@ import type { Api } from '@pc/common/types/api';
 import { useCombobox } from 'downshift';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { Badge } from '@/components/lib/Badge';
@@ -133,6 +133,7 @@ const NewAlert: NextPageWithLayout = () => {
       setCreateError('Failed to create alert.');
     }
   }
+  const resetError = useCallback(() => setCreateError(''), [setCreateError]);
 
   return (
     <Section>
@@ -555,7 +556,7 @@ const NewAlert: NextPageWithLayout = () => {
         </Form.Root>
       </Flex>
 
-      <ErrorModal error={createError} setError={setCreateError} />
+      <ErrorModal error={createError} resetError={resetError} />
     </Section>
   );
 };

--- a/frontend/pages/organizations/[slug].tsx
+++ b/frontend/pages/organizations/[slug].tsx
@@ -116,7 +116,7 @@ const RemoveUserDialog = ({
       errorText={(removeUserMutation.error as any)?.description || (removeInviteMutation.error as any)?.description}
       isProcessing={removeUserMutation.isLoading || removeInviteMutation.isLoading}
       onConfirm={removeUser}
-      setErrorText={resetError}
+      resetError={resetError}
       setShow={resetRemovingUserData}
       show={Boolean(userData)}
       title={`Are you sure you want to remove ${userData.email}?`}
@@ -213,7 +213,7 @@ const OrganizationMemberView = ({
         errorText={(leaveMutation.error as any)?.description}
         isProcessing={leaveMutation.isLoading}
         onConfirm={() => leaveMutation.mutate({ org: organization.slug, user: self.user.uid! })}
-        setErrorText={leaveMutation.reset}
+        resetError={leaveMutation.reset}
         setShow={setLeavingModalOpen}
         show={leavingModalOpen}
         title={`Are you sure you want to leave ${organization.name}?`}
@@ -404,7 +404,7 @@ const OrganizationView: NextPageWithLayout = () => {
                 errorText={(deleteMutation.error as any)?.description}
                 isProcessing={deleteMutation.isLoading}
                 onConfirm={deleteOrganization}
-                setErrorText={deleteMutation.reset}
+                resetError={deleteMutation.reset}
                 setShow={setDeleteModalOpen}
                 show={deleteModalOpen}
                 title={`Are you sure you want to delete ${selectedOrganization?.name ?? 'organization'}?`}

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -8,7 +8,7 @@ import {
 } from 'firebase/auth';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { SubmitErrorHandler, SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
@@ -138,6 +138,7 @@ export function RegisterForm() {
       });
     }
   };
+  const resetError = useCallback(() => setRegisterError(''), [setRegisterError]);
 
   return (
     <Section>
@@ -198,7 +199,7 @@ export function RegisterForm() {
             </Form.Group>
           </Flex>
 
-          <ErrorModal error={registerError} setError={setRegisterError} />
+          <ErrorModal error={registerError} resetError={resetError} />
 
           <Button stableId={StableId.REGISTER_SIGN_UP_BUTTON} stretch type="submit" loading={formState.isSubmitting}>
             Sign Up

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -1,5 +1,5 @@
 import { getIdToken, updateProfile } from 'firebase/auth';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
@@ -64,6 +64,7 @@ const Settings: NextPageWithLayout = () => {
       setIsEditing(false);
     }
   };
+  const resetError = useCallback(() => setUpdateError(''), [setUpdateError]);
 
   const onAccountDelete = async () => {
     await signOut();
@@ -79,7 +80,7 @@ const Settings: NextPageWithLayout = () => {
   return (
     <>
       <Section>
-        <ErrorModal error={updateError} setError={setUpdateError} />
+        <ErrorModal error={updateError} resetError={resetError} />
 
         <Form.Root disabled={formState.isSubmitting} onSubmit={handleSubmit(submitSettings)}>
           <Flex stack gap="l">


### PR DESCRIPTION
Please refer to [slack thread](https://pagodaplatform.slack.com/archives/C034SDNG8KT/p1669391092095779) for details.

As migrating to `react-query`-styled mutations, we'll be using `error` that is intrinsic to the library as well as `resetError` function.