### PR TITLE
Refactor: /alerts mutations

### DIFF
--- a/frontend/modules/alerts/components/AlertTableRow.tsx
+++ b/frontend/modules/alerts/components/AlertTableRow.tsx
@@ -15,7 +15,7 @@ import { DeleteAlertModal } from './DeleteAlertModal';
 
 type Alert = Api.Query.Output<'/alerts/listAlerts'>[number];
 
-export function AlertTableRow({ alert, onDelete }: { alert: Alert; onDelete: () => void }) {
+export function AlertTableRow({ alert }: { alert: Alert }) {
   const alertType = alertTypes[alert.rule.type];
   const url = `/alerts/edit-alert/${alert.id}`;
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -65,7 +65,7 @@ export function AlertTableRow({ alert, onDelete }: { alert: Alert; onDelete: () 
         </Table.Cell>
       </Table.Row>
 
-      <DeleteAlertModal alert={alert} show={showDeleteModal} setShow={setShowDeleteModal} onDelete={onDelete} />
+      <DeleteAlertModal alert={alert} show={showDeleteModal} setShow={setShowDeleteModal} />
     </>
   );
 }

--- a/frontend/modules/alerts/components/Alerts.tsx
+++ b/frontend/modules/alerts/components/Alerts.tsx
@@ -8,7 +8,6 @@ import { H1 } from '@/components/lib/Heading';
 import { Spinner } from '@/components/lib/Spinner';
 import * as Table from '@/components/lib/Table';
 import { Text } from '@/components/lib/Text';
-import { openToast } from '@/components/lib/Toast';
 import { StableId } from '@/utils/stable-ids';
 
 import { useAlerts } from '../hooks/alerts';
@@ -18,7 +17,7 @@ type Environment = Api.Query.Output<'/projects/getEnvironments'>[number];
 type Project = Api.Query.Output<'/projects/getDetails'>;
 
 export function Alerts({ environment, project }: { environment?: Environment; project?: Project }) {
-  const { alerts, mutate } = useAlerts(project?.slug, environment?.subId);
+  const { alerts } = useAlerts(project?.slug, environment?.subId);
 
   return (
     <Flex stack gap="l">
@@ -48,29 +47,9 @@ export function Alerts({ environment, project }: { environment?: Environment; pr
           </Table.Head>
 
           <Table.Body>
-            {!alerts && <Table.PlaceholderRows />}
-
-            {alerts?.map((row) => {
-              return (
-                <AlertTableRow
-                  alert={row}
-                  onDelete={() => {
-                    const name = row?.name;
-
-                    openToast({
-                      type: 'success',
-                      title: 'Alert Deleted',
-                      description: name,
-                    });
-
-                    mutate(() => {
-                      return alerts?.filter((a) => a.id !== row.id);
-                    });
-                  }}
-                  key={row.id}
-                />
-              );
-            })}
+            {alerts.map((row) => (
+              <AlertTableRow alert={row} key={row.id} />
+            ))}
           </Table.Body>
         </Table.Root>
       )}

--- a/frontend/modules/alerts/components/DeleteDestinationModal.tsx
+++ b/frontend/modules/alerts/components/DeleteDestinationModal.tsx
@@ -1,5 +1,6 @@
 import type { Api } from '@pc/common/types/api';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo } from 'react';
+import { mutate } from 'swr';
 
 import { Card } from '@/components/lib/Card';
 import { FeatherIcon } from '@/components/lib/FeatherIcon';
@@ -7,62 +8,65 @@ import { Flex } from '@/components/lib/Flex';
 import { H5 } from '@/components/lib/Heading';
 import { List, ListItem } from '@/components/lib/List';
 import { Text } from '@/components/lib/Text';
+import { openToast } from '@/components/lib/Toast';
 import { ConfirmModal } from '@/components/modals/ConfirmModal';
+import { useMutation } from '@/hooks/mutation';
 import { useSelectedProject } from '@/hooks/selected-project';
 
 import { useAlerts } from '../hooks/alerts';
-import { deleteDestination } from '../hooks/destinations';
 
 type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
-type Alerts = Api.Query.Output<'/alerts/listAlerts'>;
 
 interface Props {
   destination: Destination;
   show: boolean;
   setShow: (show: boolean) => void;
-  onDelete: () => void;
+  onDelete?: () => void;
 }
 
 export function DeleteDestinationModal({ destination, show, setShow, onDelete }: Props) {
-  const [errorText, setErrorText] = useState<string | undefined>();
-  const [isDeleting, setIsDeleting] = useState(false);
   const { environment, project } = useSelectedProject();
   const { alerts } = useAlerts(project?.slug, environment?.subId);
-  const [enabledAlerts, setEnabledAlerts] = useState<Alerts>([]);
-
-  useEffect(() => {
-    const result = alerts?.filter((alert) => {
-      const enabledDestination = alert.enabledDestinations.find((d) => d.id === destination.id);
-      return !!enabledDestination;
-    });
-
-    setEnabledAlerts(result || []);
-  }, [alerts, destination]);
-
-  async function onConfirm() {
-    setIsDeleting(true);
-    setErrorText('');
-
-    const success = await deleteDestination(destination);
-
-    if (success) {
-      onDelete();
+  const deleteDestinationMutation = useMutation('/alerts/deleteDestination', {
+    onSuccess: (_result, variables) => {
+      mutate(['/alerts/listDestinations', project!.slug], (prev) => {
+        if (!prev) {
+          return;
+        }
+        return prev.filter((destination) => destination.id !== variables.id);
+      });
+      openToast({
+        type: 'success',
+        title: 'Destination Deleted',
+        description: destination.name ?? undefined,
+      });
       setShow(false);
-    } else {
-      setErrorText('Something went wrong.');
-      setIsDeleting(false);
-    }
-  }
-  const resetError = useCallback(() => setErrorText(''), [setErrorText]);
+      onDelete?.();
+    },
+    getAnalyticsSuccessData: (variables) => ({ name: variables.id }),
+    getAnalyticsErrorData: (variables) => ({ name: variables.id }),
+  });
+  const enabledAlerts = useMemo(
+    () =>
+      alerts?.filter((alert) =>
+        alert.enabledDestinations.some((lookupDestination) => destination.id === lookupDestination.id),
+      ) ?? [],
+    [alerts, destination.id],
+  );
+
+  const onConfirm = useCallback(
+    () => deleteDestinationMutation.mutate({ id: destination.id }),
+    [deleteDestinationMutation, destination.id],
+  );
 
   return (
     <ConfirmModal
       confirmColor="danger"
       confirmText="Delete"
-      errorText={errorText}
-      isProcessing={isDeleting}
+      errorText={deleteDestinationMutation.status === 'error' ? 'Something went wrong' : undefined}
+      isProcessing={deleteDestinationMutation.isLoading}
       onConfirm={onConfirm}
-      resetError={resetError}
+      resetError={deleteDestinationMutation.reset}
       setShow={setShow}
       show={show}
       title={`Delete Destination`}

--- a/frontend/modules/alerts/components/Destinations.tsx
+++ b/frontend/modules/alerts/components/Destinations.tsx
@@ -1,5 +1,5 @@
 import type { Api } from '@pc/common/types/api';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Button } from '@/components/lib/Button';
 import { FeatherIcon } from '@/components/lib/FeatherIcon';
@@ -8,7 +8,7 @@ import { H1 } from '@/components/lib/Heading';
 import { Spinner } from '@/components/lib/Spinner';
 import * as Table from '@/components/lib/Table';
 import { Text } from '@/components/lib/Text';
-import { openToast } from '@/components/lib/Toast';
+import { useSelectedProject } from '@/hooks/selected-project';
 import { EditDestinationModal } from '@/modules/alerts/components/EditDestinationModal';
 import { NewDestinationModal } from '@/modules/alerts/components/NewDestinationModal';
 import { useDestinations } from '@/modules/alerts/hooks/destinations';
@@ -16,19 +16,14 @@ import { StableId } from '@/utils/stable-ids';
 
 import { DestinationTableRow } from './DestinationsTableRow';
 
-type Project = Api.Query.Output<'/projects/getDetails'>;
 type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
 
-export function Destinations({ project }: { project?: Project }) {
-  const { destinations, mutate } = useDestinations(project?.slug);
+export function Destinations() {
+  const { project } = useSelectedProject();
+  const { destinations } = useDestinations(project?.slug);
   const [showNewDestinationModal, setShowNewDestinationModal] = useState(false);
-  const [showEditDestinationModal, setShowEditDestinationModal] = useState(false);
   const [selectedEditDestination, setSelectedEditDestination] = useState<Destination>();
-
-  function openDestination(destination: Destination) {
-    setSelectedEditDestination(destination);
-    setShowEditDestinationModal(true);
-  }
+  const resetDestination = useCallback(() => setSelectedEditDestination(undefined), [setSelectedEditDestination]);
 
   return (
     <>
@@ -63,48 +58,17 @@ export function Destinations({ project }: { project?: Project }) {
             </Table.Head>
 
             <Table.Body>
-              {!destinations && <Table.PlaceholderRows />}
-
-              {destinations?.map((row) => {
-                return (
-                  <DestinationTableRow
-                    destination={row}
-                    onClick={() => openDestination(row)}
-                    onDelete={() => {
-                      const name = row?.name;
-
-                      openToast({
-                        type: 'success',
-                        title: 'Destination Deleted',
-                        description: name ?? undefined,
-                      });
-
-                      mutate(() => {
-                        return destinations?.filter((d) => d.id !== row.id);
-                      });
-                    }}
-                    key={row.id}
-                  />
-                );
-              })}
+              {destinations.map((row) => (
+                <DestinationTableRow destination={row} onClick={() => setSelectedEditDestination(row)} key={row.id} />
+              ))}
             </Table.Body>
           </Table.Root>
         )}
       </Flex>
-      {project && (
-        <NewDestinationModal
-          projectSlug={project.slug}
-          show={showNewDestinationModal}
-          setShow={setShowNewDestinationModal}
-        />
-      )}
+      <NewDestinationModal show={showNewDestinationModal} setShow={setShowNewDestinationModal} />
 
       {selectedEditDestination && (
-        <EditDestinationModal
-          destination={selectedEditDestination}
-          show={showEditDestinationModal}
-          setShow={setShowEditDestinationModal}
-        />
+        <EditDestinationModal destination={selectedEditDestination} resetDestination={resetDestination} />
       )}
     </>
   );

--- a/frontend/modules/alerts/components/DestinationsTableRow.tsx
+++ b/frontend/modules/alerts/components/DestinationsTableRow.tsx
@@ -16,15 +16,7 @@ import { DeleteDestinationModal } from './DeleteDestinationModal';
 
 type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
 
-export function DestinationTableRow({
-  destination,
-  onClick,
-  onDelete,
-}: {
-  destination: Destination;
-  onClick: () => void;
-  onDelete: () => void;
-}) {
+export function DestinationTableRow({ destination, onClick }: { destination: Destination; onClick: () => void }) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const destinationType = destinationTypes[destination.type];
 
@@ -80,12 +72,7 @@ export function DestinationTableRow({
         </Table.Cell>
       </Table.Row>
 
-      <DeleteDestinationModal
-        destination={destination}
-        show={showDeleteModal}
-        setShow={setShowDeleteModal}
-        onDelete={onDelete}
-      />
+      <DeleteDestinationModal destination={destination} show={showDeleteModal} setShow={setShowDeleteModal} />
     </>
   );
 }

--- a/frontend/modules/alerts/components/EditDestinationModal.tsx
+++ b/frontend/modules/alerts/components/EditDestinationModal.tsx
@@ -1,7 +1,6 @@
 import type { Api } from '@pc/common/types/api';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import type { KeyedMutator } from 'swr';
 
 import { Button } from '@/components/lib/Button';
 import * as Dialog from '@/components/lib/Dialog';
@@ -13,11 +12,13 @@ import { HR } from '@/components/lib/HorizontalRule';
 import { Text } from '@/components/lib/Text';
 import { TextButton } from '@/components/lib/TextLink';
 import { openToast } from '@/components/lib/Toast';
+import { useMutation } from '@/hooks/mutation';
+import { useSelectedProject } from '@/hooks/selected-project';
 import { formValidations } from '@/utils/constants';
 import { StableId } from '@/utils/stable-ids';
 import type { MapDiscriminatedUnion } from '@/utils/types';
 
-import { updateDestination, useDestinations } from '../hooks/destinations';
+import { useDestinations } from '../hooks/destinations';
 import { useVerifyDestinationInterval } from '../hooks/verify-destination-interval';
 import { destinationTypes } from '../utils/constants';
 import { DeleteDestinationModal } from './DeleteDestinationModal';
@@ -29,93 +30,38 @@ type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
 type DestinationType = Destination['type'];
 type MappedDestination<K extends DestinationType> = MapDiscriminatedUnion<Destination, 'type'>[K];
 
-interface Props<K extends DestinationType> {
+type Props = {
+  destination: MappedDestination<DestinationType>;
+  resetDestination: () => void;
+};
+
+interface ModalProps<K extends DestinationType> {
   destination: MappedDestination<K>;
-  show: boolean;
-  setShow: (show: boolean) => void;
+  closeEditModal: () => void;
 }
 
-interface FormProps<K extends DestinationType> extends Props<K> {
-  onUpdate: (destination: MappedDestination<K>) => void;
-}
+type FormProps<K extends DestinationType> = ModalProps<K>;
 
-interface WebhookFormProps extends FormProps<'WEBHOOK'> {
-  onSecretRotate: (destination: MappedDestination<'WEBHOOK'>) => void;
-}
-
-export function EditDestinationModal<K extends DestinationType>(props: Props<K>) {
+export function EditDestinationModal({ destination, resetDestination }: Props) {
   return (
-    <Dialog.Root open={props.show} onOpenChange={props.setShow}>
+    <Dialog.Root open={Boolean(destination)} onOpenChange={resetDestination}>
       <Dialog.Content title="Edit Destination" size="m">
         {/* The modal content is broken out in to its own component so
         that we'll have a fresh instance each time this modal opens.
         Otherwise, we'd have to worry about manually resetting the state
         and form each time it opened or closed. */}
 
-        <ModalContent {...props} />
+        <ModalContent closeEditModal={resetDestination} destination={destination} />
       </Dialog.Content>
     </Dialog.Root>
   );
 }
 
-function ModalContent<K extends DestinationType>(props: Props<K>) {
-  const { mutate } = useDestinations(props.destination.projectSlug);
+function ModalContent<K extends DestinationType>({ closeEditModal, destination }: ModalProps<K>) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const destinationType = destinationTypes[props.destination.type];
+  const destinationType = destinationTypes[destination.type];
 
-  useVerifyDestinationInterval<Destination>(
-    props.destination,
-    mutate as unknown as KeyedMutator<Destination[]>,
-    useCallback(() => props.setShow(false), [props]),
-  );
-
-  function onDelete() {
-    mutate((data) => {
-      return data?.filter((d) => d.id !== props.destination.id);
-    });
-
-    props.setShow(false);
-  }
-
-  function onUpdate(updated: MappedDestination<K>) {
-    mutate((destinations) => {
-      return destinations?.map((d) => {
-        if (d.id === updated.id) {
-          return {
-            ...updated,
-          };
-        }
-
-        return d;
-      });
-    });
-
-    openToast({
-      type: 'success',
-      title: 'Destination was updated.',
-    });
-
-    props.setShow(false);
-  }
-
-  function onWebhookSecretRotate(updated: Destination) {
-    mutate((destinations) => {
-      return destinations?.map((d) => {
-        if (d.id === updated.id) {
-          return {
-            ...updated,
-          };
-        }
-
-        return d;
-      });
-    });
-
-    openToast({
-      type: 'success',
-      title: 'Webhook secret was rotated.',
-    });
-  }
+  const formProps: FormProps<DestinationType> = { destination, closeEditModal };
 
   return (
     <>
@@ -127,9 +73,9 @@ function ModalContent<K extends DestinationType>(props: Props<K>) {
               <H5>{destinationType.name}</H5>
 
               <Text family="code" size="bodySmall">
-                {props.destination.type === 'TELEGRAM' && (props as Props<'TELEGRAM'>).destination.config.chatTitle}
-                {props.destination.type === 'WEBHOOK' && (props as Props<'WEBHOOK'>).destination.config.url}
-                {props.destination.type === 'EMAIL' && (props as Props<'EMAIL'>).destination.config.email}
+                {destination.type === 'TELEGRAM' && (destination as MappedDestination<'TELEGRAM'>).config.chatTitle}
+                {destination.type === 'WEBHOOK' && (destination as MappedDestination<'WEBHOOK'>).config.url}
+                {destination.type === 'EMAIL' && (destination as MappedDestination<'EMAIL'>).config.email}
               </Text>
             </Flex>
           </Flex>
@@ -145,27 +91,14 @@ function ModalContent<K extends DestinationType>(props: Props<K>) {
           </Button>
         </Flex>
 
-        {props.destination.type === 'TELEGRAM' && (
-          <TelegramDestinationForm
-            onUpdate={onUpdate as FormProps<'TELEGRAM'>['onUpdate']}
-            {...(props as Props<'TELEGRAM'>)}
-          />
-        )}
-        {props.destination.type === 'WEBHOOK' && (
-          <WebhookDestinationForm
-            onUpdate={onUpdate as FormProps<'WEBHOOK'>['onUpdate']}
-            onSecretRotate={onWebhookSecretRotate}
-            {...(props as Props<'WEBHOOK'>)}
-          />
-        )}
-        {props.destination.type === 'EMAIL' && (
-          <EmailDestinationForm onUpdate={onUpdate as FormProps<'EMAIL'>['onUpdate']} {...(props as Props<'EMAIL'>)} />
-        )}
+        {destination.type === 'TELEGRAM' && <TelegramDestinationForm {...(formProps as FormProps<'TELEGRAM'>)} />}
+        {destination.type === 'WEBHOOK' && <WebhookDestinationForm {...(formProps as FormProps<'WEBHOOK'>)} />}
+        {destination.type === 'EMAIL' && <EmailDestinationForm {...(formProps as FormProps<'EMAIL'>)} />}
       </Flex>
 
       <DeleteDestinationModal
-        destination={props.destination}
-        onDelete={onDelete}
+        destination={destination}
+        onDelete={closeEditModal}
         show={showDeleteModal}
         setShow={setShowDeleteModal}
       />
@@ -173,14 +106,52 @@ function ModalContent<K extends DestinationType>(props: Props<K>) {
   );
 }
 
+const useUpdateDestination = (onVerify: () => void) => {
+  const { project } = useSelectedProject();
+  const { mutate } = useDestinations(project?.slug);
+  const updateMutation = useMutation('/alerts/updateDestination', {
+    onSuccess: (result, variables) => {
+      mutate((destinations) => {
+        if (!destinations) {
+          return;
+        }
+        return destinations.map((lookupDestination) => {
+          if (lookupDestination.id !== variables.id) {
+            return lookupDestination;
+          }
+          return result;
+        });
+      });
+      openToast({
+        type: 'success',
+        title: 'Destination was updated.',
+      });
+    },
+    onError: () => {
+      openToast({
+        type: 'error',
+        title: 'Update Error',
+        description: 'Failed to update destination.',
+      });
+    },
+    getAnalyticsSuccessData: (destination) => ({
+      name: destination.name,
+      id: destination.id,
+    }),
+  });
+  useVerifyDestinationInterval(updateMutation.data, mutate, onVerify);
+  return updateMutation;
+};
+
 interface TelegramFormData {
   name: string;
 }
 
-function TelegramDestinationForm({ destination, onUpdate, setShow }: FormProps<'TELEGRAM'>) {
+function TelegramDestinationForm({ destination, closeEditModal }: FormProps<'TELEGRAM'>) {
   if (destination.type !== 'TELEGRAM') throw new Error('Invalid destination for TelegramDestinationForm');
 
   const { formState, setValue, register, handleSubmit } = useForm<TelegramFormData>();
+  const updateDestinationMutation = useUpdateDestination(closeEditModal);
 
   useEffect(() => {
     if (destination.name) {
@@ -188,30 +159,21 @@ function TelegramDestinationForm({ destination, onUpdate, setShow }: FormProps<'
     }
   }, [setValue, destination]);
 
-  async function submitForm(data: TelegramFormData) {
-    try {
-      const updated = await updateDestination<'TELEGRAM'>({
+  const submitForm = useCallback(
+    (data: TelegramFormData) => {
+      updateDestinationMutation.mutate({
         id: destination.id,
         name: data.name,
         config: {
           type: 'TELEGRAM',
         },
       });
-
-      onUpdate(updated);
-    } catch (e: any) {
-      console.error('Failed to update destination', e);
-
-      openToast({
-        type: 'error',
-        title: 'Update Error',
-        description: 'Failed to update destination.',
-      });
-    }
-  }
+    },
+    [updateDestinationMutation, destination],
+  );
 
   return (
-    <Form.Root disabled={formState.isSubmitting} onSubmit={handleSubmit(submitForm)}>
+    <Form.Root disabled={updateDestinationMutation.isLoading} onSubmit={handleSubmit(submitForm)}>
       <Flex stack gap="l">
         {!destination.isValid && (
           <>
@@ -242,15 +204,11 @@ function TelegramDestinationForm({ destination, onUpdate, setShow }: FormProps<'
           <Button
             stableId={StableId.EDIT_DESTINATION_MODAL_UPDATE_BUTTON}
             type="submit"
-            loading={formState.isSubmitting}
+            loading={updateDestinationMutation.isLoading}
           >
             Update
           </Button>
-          <TextButton
-            stableId={StableId.EDIT_DESTINATION_MODAL_CANCEL_BUTTON}
-            color="neutral"
-            onClick={() => setShow(false)}
-          >
+          <TextButton stableId={StableId.EDIT_DESTINATION_MODAL_CANCEL_BUTTON} color="neutral" onClick={closeEditModal}>
             Cancel
           </TextButton>
         </Flex>
@@ -264,10 +222,11 @@ interface WebhookFormData {
   url: string;
 }
 
-function WebhookDestinationForm({ destination, onUpdate, setShow, onSecretRotate }: WebhookFormProps) {
+function WebhookDestinationForm({ destination, closeEditModal }: FormProps<'WEBHOOK'>) {
   if (destination.type !== 'WEBHOOK') throw new Error('Invalid destination for WebhookDestinationForm');
 
   const { formState, setValue, register, handleSubmit } = useForm<WebhookFormData>();
+  const updateDestinationMutation = useUpdateDestination(closeEditModal);
 
   useEffect(() => {
     if (destination.name) {
@@ -276,9 +235,9 @@ function WebhookDestinationForm({ destination, onUpdate, setShow, onSecretRotate
     setValue('url', destination.config.url);
   }, [setValue, destination]);
 
-  async function submitForm(data: WebhookFormData) {
-    try {
-      const updated = await updateDestination<'WEBHOOK'>({
+  const submitForm = useCallback(
+    (data: WebhookFormData) => {
+      updateDestinationMutation.mutate({
         id: destination.id,
         name: data.name,
         config: {
@@ -286,23 +245,14 @@ function WebhookDestinationForm({ destination, onUpdate, setShow, onSecretRotate
           url: data.url,
         },
       });
-
-      onUpdate(updated);
-    } catch (e: any) {
-      console.error('Failed to update destination', e);
-
-      openToast({
-        type: 'error',
-        title: 'Update Error',
-        description: 'Failed to update destination.',
-      });
-    }
-  }
+    },
+    [updateDestinationMutation, destination],
+  );
 
   return (
-    <Form.Root disabled={formState.isSubmitting} onSubmit={handleSubmit(submitForm)}>
+    <Form.Root disabled={updateDestinationMutation.isLoading} onSubmit={handleSubmit(submitForm)}>
       <Flex stack gap="l">
-        <WebhookDestinationSecret destination={destination} onRotate={onSecretRotate} />
+        <WebhookDestinationSecret destination={destination} viaConfirm />
 
         <HR />
 
@@ -339,15 +289,11 @@ function WebhookDestinationForm({ destination, onUpdate, setShow, onSecretRotate
           <Button
             stableId={StableId.EDIT_DESTINATION_MODAL_UPDATE_BUTTON}
             type="submit"
-            loading={formState.isSubmitting}
+            loading={updateDestinationMutation.isLoading}
           >
             Update
           </Button>
-          <TextButton
-            stableId={StableId.EDIT_DESTINATION_MODAL_CANCEL_BUTTON}
-            color="neutral"
-            onClick={() => setShow(false)}
-          >
+          <TextButton stableId={StableId.EDIT_DESTINATION_MODAL_CANCEL_BUTTON} color="neutral" onClick={closeEditModal}>
             Cancel
           </TextButton>
         </Flex>
@@ -360,10 +306,11 @@ interface EmailFormData {
   name: string;
 }
 
-function EmailDestinationForm({ destination, onUpdate, setShow }: FormProps<'EMAIL'>) {
+function EmailDestinationForm({ destination, closeEditModal }: FormProps<'EMAIL'>) {
   if (destination.type !== 'EMAIL') throw new Error('Invalid destination for EmailDestinationForm');
 
   const { formState, setValue, register, handleSubmit } = useForm<EmailFormData>();
+  const updateDestinationMutation = useUpdateDestination(closeEditModal);
 
   useEffect(() => {
     if (destination.name) {
@@ -371,30 +318,21 @@ function EmailDestinationForm({ destination, onUpdate, setShow }: FormProps<'EMA
     }
   }, [setValue, destination]);
 
-  async function submitForm(data: EmailFormData) {
-    try {
-      const updated = await updateDestination<'EMAIL'>({
+  const submitForm = useCallback(
+    (data: EmailFormData) => {
+      updateDestinationMutation.mutate({
         id: destination.id,
         name: data.name,
         config: {
           type: 'EMAIL',
         },
       });
-
-      onUpdate(updated);
-    } catch (e: any) {
-      console.error('Failed to update destination', e);
-
-      openToast({
-        type: 'error',
-        title: 'Update Error',
-        description: 'Failed to update destination.',
-      });
-    }
-  }
+    },
+    [updateDestinationMutation, destination],
+  );
 
   return (
-    <Form.Root disabled={formState.isSubmitting} onSubmit={handleSubmit(submitForm)}>
+    <Form.Root disabled={updateDestinationMutation.isLoading} onSubmit={handleSubmit(submitForm)}>
       <Flex stack gap="l">
         {!destination.isValid && (
           <>
@@ -425,15 +363,11 @@ function EmailDestinationForm({ destination, onUpdate, setShow }: FormProps<'EMA
           <Button
             stableId={StableId.EDIT_DESTINATION_MODAL_UPDATE_BUTTON}
             type="submit"
-            loading={formState.isSubmitting}
+            loading={updateDestinationMutation.isLoading}
           >
             Update
           </Button>
-          <TextButton
-            stableId={StableId.EDIT_DESTINATION_MODAL_CANCEL_BUTTON}
-            color="neutral"
-            onClick={() => setShow(false)}
-          >
+          <TextButton stableId={StableId.EDIT_DESTINATION_MODAL_CANCEL_BUTTON} color="neutral" onClick={closeEditModal}>
             Cancel
           </TextButton>
         </Flex>

--- a/frontend/modules/alerts/components/EmailDestinationVerification.tsx
+++ b/frontend/modules/alerts/components/EmailDestinationVerification.tsx
@@ -1,12 +1,12 @@
 import type { Api } from '@pc/common/types/api';
-import { useState } from 'react';
+import { useCallback } from 'react';
 
 import { Button } from '@/components/lib/Button';
 import { Flex } from '@/components/lib/Flex';
 import { Text } from '@/components/lib/Text';
+import { openToast } from '@/components/lib/Toast';
+import { useMutation } from '@/hooks/mutation';
 import { StableId } from '@/utils/stable-ids';
-
-import { resendEmailVerification } from '../hooks/destinations';
 
 type Destination = Api.Query.Output<'/alerts/listDestinations'>[number];
 
@@ -15,15 +15,33 @@ interface Props {
 }
 
 export function EmailDestinationVerification({ destination }: Props) {
-  const [isSending, setIsSending] = useState(false);
+  const resendEmailVerificationMutation = useMutation('/alerts/resendEmailVerification', {
+    onSuccess: () => {
+      openToast({
+        type: 'success',
+        title: 'Verification Sent',
+        description: 'Check your inbox and spam folder.',
+      });
+    },
+    onError: () => {
+      openToast({
+        type: 'error',
+        title: 'Send Failure',
+        description: `Failed to send verification email. Please try again later.`,
+      });
+    },
+    getAnalyticsSuccessData: ({ destinationId }) => ({ name: destinationId }),
+    getAnalyticsErrorData: ({ destinationId }) => ({ name: destinationId }),
+  });
 
-  async function resend() {
-    setIsSending(true);
-    await resendEmailVerification(destination.id);
-    setIsSending(false);
+  const resend = useCallback(
+    () => resendEmailVerificationMutation.mutate({ destinationId: destination.id }),
+    [destination.id, resendEmailVerificationMutation],
+  );
+
+  if (destination.type !== 'EMAIL') {
+    return null;
   }
-
-  if (destination.type !== 'EMAIL') return null;
 
   return (
     <Flex stack gap="l">
@@ -39,7 +57,7 @@ export function EmailDestinationVerification({ destination }: Props) {
         <Button
           stableId={StableId.EMAIL_DESTINATION_VERIFICATION_RESEND_BUTTON}
           color="neutral"
-          loading={isSending}
+          loading={resendEmailVerificationMutation.isLoading}
           onClick={resend}
         >
           Resend Verification Email

--- a/frontend/modules/alerts/components/WebhookDestinationSecret.tsx
+++ b/frontend/modules/alerts/components/WebhookDestinationSecret.tsx
@@ -1,5 +1,6 @@
 import type { Api } from '@pc/common/types/api';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import { mutate } from 'swr';
 
 import { Button } from '@/components/lib/Button';
 import { Card } from '@/components/lib/Card';
@@ -8,10 +9,10 @@ import { Flex } from '@/components/lib/Flex';
 import { Text } from '@/components/lib/Text';
 import { openToast } from '@/components/lib/Toast';
 import { ConfirmModal } from '@/components/modals/ConfirmModal';
+import { useMutation } from '@/hooks/mutation';
+import { useSelectedProject } from '@/hooks/selected-project';
 import { StableId } from '@/utils/stable-ids';
 import type { MapDiscriminatedUnion } from '@/utils/types';
-
-import { rotateWebhookDestinationSecret } from '../hooks/destinations';
 
 type WebhookDestination = MapDiscriminatedUnion<
   Api.Query.Output<'/alerts/listDestinations'>[number],
@@ -20,40 +21,50 @@ type WebhookDestination = MapDiscriminatedUnion<
 
 interface Props {
   destination: WebhookDestination;
-  onRotate?: (d: WebhookDestination) => void;
+  viaConfirm?: boolean;
 }
 
 const ROTATION_WARNING =
   'Are you sure you would like to rotate this webhook secret? The current secret will be invalidated.';
 
-export function WebhookDestinationSecret({ destination, onRotate }: Props) {
-  const [isSending, setIsSending] = useState(false);
+export function WebhookDestinationSecret({ destination, viaConfirm }: Props) {
+  const { project } = useSelectedProject();
   const [showRotateConfirmModal, setShowRotateConfirmModal] = useState(false);
-
-  if (destination.type !== 'WEBHOOK') return null;
-
-  const authorizationHeader = `Bearer ${destination.config.secret}`;
-
-  async function rotateSecret() {
-    if (destination.type !== 'WEBHOOK') return;
-    if (!onRotate) return;
-
-    try {
-      setIsSending(true);
-      const res = await rotateWebhookDestinationSecret(destination.id);
-      if (res.type !== 'WEBHOOK') return;
-      onRotate(res);
-    } catch (e) {
-      console.error('Failed to rotate webhook secret.', e);
+  const rotateWebhookDestinationSecretMutation = useMutation('/alerts/rotateWebhookDestinationSecret', {
+    onSuccess: (result) => {
+      mutate(['/alerts/listDestinations', project!.slug], (destinations) => {
+        if (!destinations) {
+          return;
+        }
+        return destinations.map((lookupDestination) => {
+          if (lookupDestination.id !== destination.id) {
+            return lookupDestination;
+          }
+          const webhookDestination = lookupDestination as WebhookDestination;
+          return { ...webhookDestination, config: { ...webhookDestination.config, secret: result.config.secret } };
+        });
+      });
+      openToast({
+        type: 'success',
+        title: 'Webhook secret was rotated.',
+      });
+    },
+    onError: () => {
       openToast({
         type: 'error',
         title: 'Failed to rotate webhook secret.',
       });
-    } finally {
-      setIsSending(false);
-      setShowRotateConfirmModal(false);
-    }
-  }
+    },
+    onSettled: () => setShowRotateConfirmModal(false),
+    getAnalyticsSuccessData: ({ destinationId }) => ({ id: destinationId }),
+  });
+
+  const rotate = useCallback(
+    () => rotateWebhookDestinationSecretMutation.mutate({ destinationId: destination.id }),
+    [rotateWebhookDestinationSecretMutation, destination.id],
+  );
+
+  const authorizationHeader = `Bearer ${destination.config.secret}`;
 
   return (
     <>
@@ -74,21 +85,21 @@ export function WebhookDestinationSecret({ destination, onRotate }: Props) {
               value={authorizationHeader}
               color="transparent"
             />
-            {onRotate && (
+            {viaConfirm ? (
               <Button
                 stableId={StableId.WEBHOOK_DESTINATION_SECRET_ROTATE_SECRET_BUTTON}
                 color="neutral"
-                loading={isSending}
+                loading={rotateWebhookDestinationSecretMutation.isLoading}
                 onClick={() => setShowRotateConfirmModal(true)}
               >
                 Rotate
               </Button>
-            )}
+            ) : null}
           </Flex>
         </Card>
       </Flex>
       <ConfirmModal
-        onConfirm={rotateSecret}
+        onConfirm={rotate}
         setShow={setShowRotateConfirmModal}
         show={showRotateConfirmModal}
         title="Rotate secret"

--- a/frontend/modules/alerts/hooks/destinations.ts
+++ b/frontend/modules/alerts/hooks/destinations.ts
@@ -1,116 +1,16 @@
-import type { Alerts } from '@pc/common/types/alerts';
-import type { Api } from '@pc/common/types/api';
 import useSWR from 'swr';
 
-import { openToast } from '@/components/lib/Toast';
-import { useAuth } from '@/hooks/auth';
-import analytics from '@/utils/analytics';
 import { fetchApi } from '@/utils/http';
-import type { MapDiscriminatedUnion } from '@/utils/types';
-
-export async function createDestination(data: Api.Mutation.Input<'/alerts/createDestination'>) {
-  const destination = await fetchApi(['/alerts/createDestination', { ...data }]);
-
-  analytics.track('DC Create New Destination', {
-    status: 'success',
-    name: destination.name,
-    id: destination.id,
-  });
-
-  return destination;
-}
-
-export async function deleteDestination(destination: Api.Mutation.Input<'/alerts/deleteDestination'>) {
-  try {
-    await fetchApi(['/alerts/deleteDestination', { id: destination.id }]);
-    analytics.track('DC Remove Destination', {
-      status: 'success',
-      name: destination.id,
-    });
-    return true;
-  } catch (e: any) {
-    analytics.track('DC Remove Destination', {
-      status: 'failure',
-      name,
-      error: e.message,
-    });
-    // TODO
-    console.error('Failed to delete alert');
-  }
-  return false;
-}
-
-export async function updateDestination<K extends Alerts.Destination['type']>(
-  data: Api.Mutation.Input<'/alerts/updateDestination'>,
-) {
-  const destination = await fetchApi(['/alerts/updateDestination', { ...data }]);
-
-  analytics.track('DC Update Destination', {
-    status: 'success',
-    name: destination.name,
-    id: destination.id,
-  });
-
-  return destination as MapDiscriminatedUnion<Alerts.Destination, 'type'>[K];
-}
 
 export function useDestinations(projectSlug: string | undefined) {
-  const { identity } = useAuth();
-
   const {
     data: destinations,
     error,
     mutate,
     isValidating,
-  } = useSWR(
-    identity && projectSlug ? ['/alerts/listDestinations' as const, projectSlug, identity.uid] : null,
-    (key) => {
-      return fetchApi([key, { projectSlug: projectSlug! }]);
-    },
-  );
-
-  return { destinations, error, mutate, isValidating };
-}
-
-export async function resendEmailVerification(destinationId: number) {
-  try {
-    await fetchApi(['/alerts/resendEmailVerification', { destinationId }]);
-
-    analytics.track('DC Resend Email Verification for Email Destination', {
-      status: 'success',
-      name: destinationId,
-    });
-
-    openToast({
-      type: 'success',
-      title: 'Verification Sent',
-      description: 'Check your inbox and spam folder.',
-    });
-
-    return true;
-  } catch (e: any) {
-    analytics.track('DC Resend Email Verification for Email Destination', {
-      status: 'failure',
-      error: e.message,
-    });
-
-    openToast({
-      type: 'error',
-      title: 'Send Failure',
-      description: `Failed to send verification email. Please try again later.`,
-    });
-
-    return false;
-  }
-}
-
-export async function rotateWebhookDestinationSecret(destinationId: Alerts.DestinationId) {
-  const destination = await fetchApi(['/alerts/rotateWebhookDestinationSecret', { destinationId }]);
-
-  analytics.track('DC Rotate Webhook Destination Secret', {
-    status: 'success',
-    id: destination.id,
+  } = useSWR(projectSlug ? ['/alerts/listDestinations' as const, projectSlug] : null, (key) => {
+    return fetchApi([key, { projectSlug: projectSlug! }]);
   });
 
-  return destination;
+  return { destinations, error, mutate, isValidating };
 }

--- a/frontend/pages/alerts/index.tsx
+++ b/frontend/pages/alerts/index.tsx
@@ -48,7 +48,7 @@ function ListAlerts() {
         </Tabs.Content>
 
         <Tabs.Content value="destinations">
-          <Destinations project={project} />
+          <Destinations />
         </Tabs.Content>
       </Tabs.Root>
     </Section>

--- a/frontend/pages/alerts/unsubscribe-from-email-alert.tsx
+++ b/frontend/pages/alerts/unsubscribe-from-email-alert.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 
 import { Container } from '@/components/lib/Container';
 import { Flex } from '@/components/lib/Flex';
@@ -7,44 +7,37 @@ import { Message } from '@/components/lib/Message';
 import { Section } from '@/components/lib/Section';
 import { Spinner } from '@/components/lib/Spinner';
 import { useSimpleLayout } from '@/hooks/layouts';
-import { fetchApi } from '@/utils/http';
+import { useMutation } from '@/hooks/mutation';
 import type { NextPageWithLayout } from '@/utils/types';
 
 const Unsubscribe: NextPageWithLayout = () => {
-  const [unsubscribeMessage, setUnsubscribeMessage] = useState('');
-  const [error, setError] = useState('');
   const router = useRouter();
   const { token } = router.query;
-  const hasSentRequest = useRef(false);
 
+  const unsubscribeFromEmailAlertMutation = useMutation('/alerts/unsubscribeFromEmailAlert', { unauth: true });
   useEffect(() => {
     if (typeof token !== 'string') {
       return;
     }
-
-    if (!hasSentRequest.current) {
-      sendUnsubscribeRequest(token);
-      hasSentRequest.current = true;
-    }
-  }, [token]);
-
-  async function sendUnsubscribeRequest(token: string) {
-    try {
-      await fetchApi(['/alerts/unsubscribeFromEmailAlert', { token }], true);
-      setUnsubscribeMessage('You have successfully unsubscribed from this email alert. You may close this window.');
-    } catch (e) {
-      console.error(e);
-      setError('Something went wrong while trying to unsubscribe from this email alert.');
-    }
-  }
+    unsubscribeFromEmailAlertMutation.mutate({ token });
+  }, [token, unsubscribeFromEmailAlertMutation]);
 
   return (
     <Section>
       <Container size="s">
         <Flex stack align="center">
-          {!unsubscribeMessage && !error && <Spinner size="m" />}
-          {error && <Message content={error} type="error" />}
-          {unsubscribeMessage && <Message content={unsubscribeMessage} type="success" />}
+          {unsubscribeFromEmailAlertMutation.status === 'loading' ? (
+            <Spinner size="m" />
+          ) : unsubscribeFromEmailAlertMutation.status === 'error' ? (
+            <Message content="Something went wrong while trying to unsubscribe from this email alert." type="error" />
+          ) : unsubscribeFromEmailAlertMutation.status === 'idle' ? (
+            <Message content="Something is wrong with the token. Please verify the link." />
+          ) : (
+            <Message
+              content="You have successfully unsubscribed from this email alert. You may close this window."
+              type="success"
+            />
+          )}
         </Flex>
       </Container>
     </Section>

--- a/frontend/pages/alerts/verify-email.tsx
+++ b/frontend/pages/alerts/verify-email.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 
 import { Container } from '@/components/lib/Container';
 import { Flex } from '@/components/lib/Flex';
@@ -7,45 +7,39 @@ import { Message } from '@/components/lib/Message';
 import { Section } from '@/components/lib/Section';
 import { Spinner } from '@/components/lib/Spinner';
 import { useSimpleLayout } from '@/hooks/layouts';
-import { fetchApi } from '@/utils/http';
+import { useMutation } from '@/hooks/mutation';
 import type { NextPageWithLayout } from '@/utils/types';
 
 const Verification: NextPageWithLayout = () => {
-  const [verificationMessage, setVerificationMessage] = useState('');
-  const [error, setError] = useState('');
   const router = useRouter();
   const { token } = router.query;
-  const hasSentRequest = useRef(false);
-
+  const verifyEmailDestinationMutation = useMutation('/alerts/verifyEmailDestination', { unauth: true });
   useEffect(() => {
     if (typeof token !== 'string') {
       return;
     }
-
-    if (!hasSentRequest.current) {
-      sendVerification(token);
-      hasSentRequest.current = true;
-    }
-  }, [token]);
-
-  async function sendVerification(token: string) {
-    try {
-      await fetchApi(['/alerts/verifyEmailDestination', { token }], true);
-      setVerificationMessage('Your email destination is now ready to receive alerts! You may close this window.');
-    } catch (e) {
-      // TODO handle expired token
-      console.error(e);
-      setError('Something went wrong while trying to verify your email. Please check your destination.');
-    }
-  }
+    verifyEmailDestinationMutation.mutate({ token });
+  }, [token, verifyEmailDestinationMutation]);
 
   return (
     <Section>
       <Container size="s">
         <Flex stack align="center">
-          {!verificationMessage && !error && <Spinner size="m" />}
-          {error && <Message content={error} type="error" />}
-          {verificationMessage && <Message content={verificationMessage} type="success" />}
+          {verifyEmailDestinationMutation.status === 'loading' ? (
+            <Spinner size="m" />
+          ) : verifyEmailDestinationMutation.status === 'error' ? (
+            <Message
+              content="Something went wrong while trying to verify your email. Please check your destination."
+              type="error"
+            />
+          ) : verifyEmailDestinationMutation.status === 'idle' ? (
+            <Message content="Something is wrong with the token. Please verify the link." />
+          ) : (
+            <Message
+              content="Your email destination is now ready to receive alerts! You may close this window."
+              type="success"
+            />
+          )}
         </Flex>
       </Container>
     </Section>


### PR DESCRIPTION
Please refer to [slack thread](https://pagodaplatform.slack.com/archives/C034SDNG8KT/p1669391092095779) for details.

Migrating `/alerts` mutations to `react-query` hook style.