### PR TITLE
Refactor: /abi queries

### DIFF
--- a/frontend/modules/contracts/components/ContractAbi.tsx
+++ b/frontend/modules/contracts/components/ContractAbi.tsx
@@ -18,7 +18,7 @@ export const ContractAbi = ({ contract }: Props) => {
 
   return (
     <Flex gap="l" stack="true" autoWidth>
-      {(embeddedQuery.isValidating || privateQuery.isValidating) && <Spinner size="m" center />}
+      {(embeddedQuery.isValidating || privateQuery.isLoading) && <Spinner size="m" center />}
       {embeddedQuery.data && <Message type="info" content="This contract has an embedded ABI." />}
       {abi && <CodeBlock language="json">{JSON.stringify(abi, null, 2)}</CodeBlock>}
     </Flex>

--- a/frontend/modules/contracts/hooks/abi.ts
+++ b/frontend/modules/contracts/hooks/abi.ts
@@ -5,8 +5,8 @@ import { connect, keyStores } from 'near-api-js';
 import useSWR from 'swr';
 
 import { usePublicMode } from '@/hooks/public';
+import { useQuery } from '@/hooks/query';
 import config from '@/utils/config';
-import { fetchApi } from '@/utils/http';
 
 import { inspectContract } from '../utils/embedded-abi';
 
@@ -21,11 +21,10 @@ export const useEmbeddedAbi = (contract?: Contract) => {
   );
 };
 
-export const usePrivateAbi = (contract?: Contract) => {
-  return useSWR(contract ? ['/abi/getContractAbi', contract] : null, () =>
-    fetchApi(['/abi/getContractAbi', { contract: contract!.slug }]),
-  );
-};
+export const usePrivateAbi = (contract?: Contract) =>
+  useQuery(['/abi/getContractAbi', { contract: contract?.slug || 'unknown' }], {
+    enabled: Boolean(contract),
+  });
 
 // Returns both embedded ABI in the wasm and manually uploaded ABI.
 export const useAnyAbi = (contract?: Contract) => {


### PR DESCRIPTION
Please refer to [slack thread](https://pagodaplatform.slack.com/archives/C034SDNG8KT/p1669391092095779) for details.

Migrating `/abi` queries to `react-query` hook style.