### PR TITLE
fix launchdarkly's user tracking

### DIFF
--- a/frontend/hooks/analytics.ts
+++ b/frontend/hooks/analytics.ts
@@ -1,3 +1,4 @@
+import { useLDClient } from 'launchdarkly-react-client-sdk';
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 
@@ -13,6 +14,7 @@ export function useAnalytics() {
   const { authStatus } = useAuth();
   const { user } = useAccount();
   const [hasIdentified, setHasIdentified] = useState(false);
+  const ldClient = useLDClient();
 
   useEffect(() => {
     if (user?.uid) {
@@ -24,9 +26,11 @@ export function useAnalytics() {
         userId: user.uid,
       });
 
+      if (ldClient) ldClient.identify({ key: user.uid });
+
       setHasIdentified(true);
     }
-  }, [user]);
+  }, [ldClient, user]);
 
   useEffect(() => {
     let page;

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -115,6 +115,9 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
 
 export default withLDProvider({
   clientSideID: config.launchDarklyEnv,
+  user: {
+    key: 'anonymous-placeholder-id',
+  },
   reactOptions: {
     useCamelCaseFlagKeys: false,
   },


### PR DESCRIPTION
LD currently tracks over 18k anonymous users as contributing to our MAU count. This PR follows their recommendation to use a [shared key](https://docs.launchdarkly.com/home/users/anonymous-users#tracking-anonymous-users-with-a-shared-key) to track users until a reliable user Id is available. 