### PR TITLE
Add Deploy: Gallery

### DIFF
--- a/frontend/components/GithubConnect.tsx
+++ b/frontend/components/GithubConnect.tsx
@@ -16,7 +16,6 @@ import { StableId } from '@/utils/stable-ids';
 
 import { ButtonLink } from './lib/Button';
 import { FeatherIcon } from './lib/FeatherIcon';
-import { HR } from './lib/HorizontalRule';
 import { Message } from './lib/Message';
 import { Spinner } from './lib/Spinner';
 import { Text } from './lib/Text';
@@ -101,7 +100,7 @@ export function GithubConnect(props: Props) {
 
 function Connected({ children, handle }: { children: ReactElement; handle: string }) {
   return (
-    <Flex stack>
+    <Flex stack gap="l">
       <Flex align="center">
         <FeatherIcon icon="github" size="s" />
         <Text size="bodySmall">
@@ -111,8 +110,6 @@ function Connected({ children, handle }: { children: ReactElement; handle: strin
           </TextLink>
         </Text>
       </Flex>
-
-      <HR />
 
       {children}
     </Flex>


### PR DESCRIPTION
Added `/deploys/addDeploy` mutation  inside `DeployTemplateModal.tsx`

- Handles errors (displays API error on 400)
- Handles success by showing toast and closing modal. Will probably want to add a redirect to deploys module in the future (left a `TODO` comment).