### PR TITLE
Hotfix: fix transaction details issues

### DIFF
--- a/backend/src/config/validate.ts
+++ b/backend/src/config/validate.ts
@@ -99,6 +99,7 @@ export interface AppConfig {
 
 const databaseSchema = Joi.object({
   host: Joi.string(),
+  port: Joi.number().integer().optional(),
   database: Joi.string(),
   user: Joi.string(),
   password: Joi.string(),
@@ -250,6 +251,7 @@ export default function validate(config: Record<string, unknown>): AppConfig {
       MAINNET: {
         host:
           config.INDEXER_MAINNET_HOST || 'mainnet.db.explorer.indexer.near.dev',
+        port: config.INDEXER_MAINNET_PORT,
         database: config.INDEXER_MAINNET_DATABASE || 'mainnet_explorer',
         user: config.INDEXER_MAINNET_USER || 'public_readonly',
         password: config.INDEXER_MAINNET_PASSWORD || 'nearprotocol',
@@ -257,6 +259,7 @@ export default function validate(config: Record<string, unknown>): AppConfig {
       TESTNET: {
         host:
           config.INDEXER_TESTNET_HOST || 'testnet.db.explorer.indexer.near.dev',
+        port: config.INDEXER_TESTNET_PORT,
         database: config.INDEXER_TESTNET_DATABASE || 'testnet_explorer',
         user: config.INDEXER_TESTNET_USER || 'public_readonly',
         password: config.INDEXER_TESTNET_PASSWORD || 'nearprotocol',

--- a/backend/src/core/explorer/explorer.service.ts
+++ b/backend/src/core/explorer/explorer.service.ts
@@ -320,11 +320,15 @@ const collectNestedReceiptWithOutcome = (
 ): Explorer.NestedReceiptWithOutcome => {
   const parsedElement = parsedMap.get(idOrHash)!;
   const { receiptIds, ...restOutcome } = parsedElement.outcome;
+  // TODO instead of filtering receipts out, we should be getting the details from RPC in the EXPERIMENTAL_tx_status call
+  // but RPC stopped providing refund receipt's details so we needed to put this fix in place.
+  // Right now, filtering out the receipts is easier than trying to return just the id of the receipt if the details are not found.
+  const filteredReceipts = receiptIds.filter((id) => parsedMap.has(id));
   return {
     ...parsedElement,
     outcome: {
       ...restOutcome,
-      nestedReceipts: receiptIds.map((id) =>
+      nestedReceipts: filteredReceipts.map((id) =>
         collectNestedReceiptWithOutcome(id, parsedMap),
       ),
     },

--- a/backend/src/core/explorer/indexer.service.ts
+++ b/backend/src/core/explorer/indexer.service.ts
@@ -55,6 +55,7 @@ export class IndexerService {
         indexerDatabaseConfig.MAINNET.password,
         {
           host: indexerDatabaseConfig.MAINNET.host,
+          port: indexerDatabaseConfig.MAINNET.port,
           dialect: 'postgres',
           logging: this.config.get('log.indexer', { infer: true })
             ? console.log
@@ -67,6 +68,7 @@ export class IndexerService {
         indexerDatabaseConfig.TESTNET.password,
         {
           host: indexerDatabaseConfig.TESTNET.host,
+          port: indexerDatabaseConfig.TESTNET.port,
           dialect: 'postgres',
           logging: this.config.get('log.indexer', { infer: true })
             ? console.log

--- a/frontend/components/explorer/transaction/InspectReceipt.tsx
+++ b/frontend/components/explorer/transaction/InspectReceipt.tsx
@@ -73,6 +73,7 @@ const InspectReceipt: React.FC<Props> = React.memo(({ receipt: { id, ...receipt 
   const receiverBalance = query.data?.[0];
 
   const gasAttached = getGasAttached(receipt.actions);
+  // TODO this will always show 0 because we are no longer receiving refund receipt details from RPC
   const refund =
     receipt.outcome.nestedReceipts
       .filter((receipt) => receipt.predecessorId === 'system')

--- a/frontend/components/explorer/transaction/TransactionActions.tsx
+++ b/frontend/components/explorer/transaction/TransactionActions.tsx
@@ -168,14 +168,13 @@ const TransactionActionsList: React.FC<ListProps> = React.memo(({ transaction })
     setActiveReceipts(receipts);
   }, [activeReceipts, toggleType]);
 
-  const nestedReceipts = transaction.receipt.outcome.nestedReceipts;
   const pending = React.useMemo(() => {
-    const completedTimestamp = nestedReceipts.at(-1)?.outcome?.block?.timestamp;
+    const completedTimestamp = transaction.receipt?.outcome?.block?.timestamp;
     if (!completedTimestamp) {
       return <Placeholder css={{ display: 'inline-block', width: '8rem' }} />;
     }
     return toHuman(Interval.fromDateTimes(new Date(transaction.timestamp), new Date(completedTimestamp)).toDuration());
-  }, [transaction.timestamp, nestedReceipts]);
+  }, [transaction.timestamp, transaction.receipt]);
 
   const toggleReceipts = (id: string) => {
     setActiveReceipts((prevState) => {
@@ -206,7 +205,7 @@ const TransactionActionsList: React.FC<ListProps> = React.memo(({ transaction })
         <TitleWrapper>
           <div>
             <H4>Execution Plan</H4>
-            <span>Processed in {pending}</span>
+            <span>Processed in {pending === '0 seconds' ? '< 1 second' : pending}</span>
           </div>
           <Button stableId={StableId.TRANSACTION_ACTIONS_RESPONSE_EXPAND_BUTTON} size="s" onClick={toggleAllReceipts}>
             {toggleType === 'toggle' ? 'Collapse all -' : 'Expand All + '}


### PR DESCRIPTION
Changes:
- explorer DB configuration changes so we can point to a pgbouncer instance
- fix issue with RPC's EXECUTION_tx_status no longer returning all receipts (see [similar explorer PR](https://github.com/near/near-explorer/pull/1137/files))