### PR TITLE
Fix: mocking keys service env var

### DIFF
--- a/backend/src/config/validate.ts
+++ b/backend/src/config/validate.ts
@@ -253,13 +253,14 @@ export default function validate(config: Record<string, any>): AppConfig {
       },
     },
     metricsPort: config.METRICS_PORT,
-    rpcProvisioningService: config.MOCK_KEY_SERVICE
-      ? { mock: true }
-      : {
-          mock: false,
-          url: config.RPC_API_KEYS_URL,
-          apiKey: config.RPC_API_KEYS_API_KEY,
-        },
+    rpcProvisioningService:
+      config.MOCK_KEY_SERVICE === 'true'
+        ? { mock: true }
+        : {
+            mock: false,
+            url: config.RPC_API_KEYS_URL,
+            apiKey: config.RPC_API_KEYS_API_KEY,
+          },
     github: {
       clientId: config.GITHUB_CONNECT_CLIENT_ID,
       clientSecret: config.GITHUB_CONNECT_CLIENT_SECRET,


### PR DESCRIPTION
This change fixes a regression that will allow us to set `MOCK_KEYS_SERVICE=false` in our `.env.nest.local`.

In Develop branch, you cannot override the `.env.nest`'s `MOCK_KEYS_SERVICE` to the string `false` in your `.env.nest.local`. The problem is that we were checking if `MOCK_KEYS_SERVICE` is set to any string, so setting to `false` doesn't actually turn the feature off. The only way to turn it off is to remove the env var from `.env.nest` which creates a git diff which I do not want when I'm developing.