### PR TITLE
Feat: deny rendering in iframes

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,10 @@ const moduleExports = {
             key: 'X-Frame-Options',
             value: 'DENY',
           },
+          {
+            key: 'Content-Security-Policy',
+            value: "frame-ancestors 'none'",
+          },
         ],
       },
     ];


### PR DESCRIPTION
To prevent clickjacking, we are now going to set response headers to prevent rendering console in an iframe.

Putting console in an iframe now gives a dev this error: 
![image](https://user-images.githubusercontent.com/6013783/219517726-c3472365-a094-4c83-9f0c-82e4c3978689.png)


closes [DEC-851](https://pagodaplatform.atlassian.net/browse/DEC-851)